### PR TITLE
[UI/#91] 리듬뷰 / Compose Migration

### DIFF
--- a/buildSrc/src/main/kotlin/Dependencies.kt
+++ b/buildSrc/src/main/kotlin/Dependencies.kt
@@ -99,6 +99,7 @@ object ComposeDependencies {
     const val hiltNavigationCompose = "androidx.hilt:hilt-navigation-compose:${Versions.hiltNavigationCompose}"
     const val androidxUiGraphics = "androidx.compose.ui:ui-graphics:${Versions.androidxComposeCompiler}"
     const val androidxImmutableList = "org.jetbrains.kotlinx:kotlinx-collections-immutable:${Versions.kotlinxImmutable}"
+    const val lottieCompose = "com.airbnb.android:lottie-compose:${Versions.lottieVersion}"
 }
 
 object ComposePlugins {

--- a/buildSrc/src/main/kotlin/Dependencies.kt
+++ b/buildSrc/src/main/kotlin/Dependencies.kt
@@ -100,6 +100,7 @@ object ComposeDependencies {
     const val androidxUiGraphics = "androidx.compose.ui:ui-graphics:${Versions.androidxComposeCompiler}"
     const val androidxImmutableList = "org.jetbrains.kotlinx:kotlinx-collections-immutable:${Versions.kotlinxImmutable}"
     const val lottieCompose = "com.airbnb.android:lottie-compose:${Versions.lottieVersion}"
+    const val accompanist = "com.google.accompanist:accompanist-systemuicontroller:${Versions.accompanistVersion}"
 }
 
 object ComposePlugins {

--- a/buildSrc/src/main/kotlin/Versions.kt
+++ b/buildSrc/src/main/kotlin/Versions.kt
@@ -54,4 +54,5 @@ object Versions {
     const val composePluginVersion = "1.5.3"
 
     const val kotlinxImmutable = "0.3.7"
+    const val accompanistVersion = "0.31.3-beta"
 }

--- a/presentation/build.gradle.kts
+++ b/presentation/build.gradle.kts
@@ -112,5 +112,6 @@ dependencies {
         implementation(androidxUiGraphics)
         implementation(androidxImmutableList)
         implementation(lottieCompose)
+        implementation(accompanist)
     }
 }

--- a/presentation/build.gradle.kts
+++ b/presentation/build.gradle.kts
@@ -111,5 +111,6 @@ dependencies {
         implementation(hiltNavigationCompose)
         implementation(androidxUiGraphics)
         implementation(androidxImmutableList)
+        implementation(lottieCompose)
     }
 }

--- a/presentation/src/main/java/com/kkkk/presentation/main/MainScreen.kt
+++ b/presentation/src/main/java/com/kkkk/presentation/main/MainScreen.kt
@@ -1,5 +1,6 @@
 package com.kkkk.presentation.main
 
+import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.Scaffold
 import androidx.compose.runtime.Composable
@@ -9,6 +10,7 @@ import com.kkkk.presentation.main.profile.navigation.profileNavGraph
 import com.kkkk.presentation.main.record.navigation.recordNavGraph
 import com.kkkk.presentation.main.result.navigation.resultNavGraph
 import com.kkkk.presentation.main.rhythm.navigation.rhythmNavGraph
+import com.kkkk.presentation.main.theme.White
 import kotlinx.collections.immutable.toImmutableList
 
 @Composable
@@ -28,7 +30,9 @@ fun MainScreen(
         },
         content = { paddingValue ->
             NavHost(
-                modifier = Modifier.padding(paddingValue),
+                modifier = Modifier
+                    .padding(paddingValue)
+                    .background(White),
                 startDestination = navigator.startDestination,
                 navController = navigator.navController,
             ) {

--- a/presentation/src/main/java/com/kkkk/presentation/main/rhythm/RhythmMode.kt
+++ b/presentation/src/main/java/com/kkkk/presentation/main/rhythm/RhythmMode.kt
@@ -1,0 +1,6 @@
+package com.kkkk.presentation.main.rhythm
+
+enum class RhythmMode(val text: String) {
+    RHYTHM("리듬모드"),
+    STRETCH("스트레칭")
+}

--- a/presentation/src/main/java/com/kkkk/presentation/main/rhythm/RhythmScreen.kt
+++ b/presentation/src/main/java/com/kkkk/presentation/main/rhythm/RhythmScreen.kt
@@ -10,6 +10,7 @@ import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.aspectRatio
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.heightIn
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.shape.RoundedCornerShape
@@ -24,6 +25,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.draw.scale
 import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.platform.LocalConfiguration
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.res.vectorResource
 import androidx.compose.ui.text.style.TextAlign
@@ -57,8 +59,13 @@ fun RhythmRoute(
         LottieCompositionSpec.RawRes(rhythmState.lottieResource)
     )
 
-    val sheetState = rememberModalBottomSheetState()
+    val sheetState = rememberModalBottomSheetState(
+        skipPartiallyExpanded = true,
+    )
     val scope = rememberCoroutineScope()
+
+    val screenHeight = LocalConfiguration.current.screenHeightDp.dp
+    val maxHeight = screenHeight * 0.9f
 
     RhythmScreen(
         rhythmState = rhythmState,
@@ -73,10 +80,12 @@ fun RhythmRoute(
         RhythmBottomSheet(
             rhythmState = rhythmState,
             sheetState = sheetState,
+            modifier = Modifier.heightIn(max = maxHeight),
             onDismissRequest = { viewModel.showBottomSheet(false) },
             onSubmitBtnClick = { bit, bpm ->
-                scope.launch { sheetState.hide() }.invokeOnCompletion {
+                scope.launch {
                     viewModel.updateRhythm(bit, bpm)
+                    sheetState.hide()
                     viewModel.showBottomSheet(false)
                 }
             }
@@ -125,93 +134,92 @@ internal fun RhythmScreen(
                     .scale(1.5f)
             )
         }
-    }
-
-    Column(
-        modifier = Modifier.fillMaxSize(),
-    ) {
-        Box(
-            modifier = Modifier.padding(top = 24.dp),
-            contentAlignment = Alignment.CenterEnd
+        Column(
+            modifier = Modifier.fillMaxSize(),
         ) {
-            RhythmModeToggle(
-                modifier = Modifier.padding(horizontal = 60.dp),
-                selectedMode = rhythmState.selectedMode,
-                onToggleSelected = onToggleSelected
-            )
-            if (rhythmState.selectedMode == RhythmMode.RHYTHM) {
-                Image(
-                    imageVector = ImageVector.vectorResource(R.drawable.ic_watch),
-                    contentDescription = null,
-                    modifier = Modifier
-                        .padding(end = 8.dp)
-                        .clickableWithoutRipple { onWatchBtnClick() }
-                        .padding(6.dp)
+            Box(
+                modifier = Modifier.padding(top = 24.dp),
+                contentAlignment = Alignment.CenterEnd
+            ) {
+                RhythmModeToggle(
+                    modifier = Modifier.padding(horizontal = 60.dp),
+                    selectedMode = rhythmState.selectedMode,
+                    onToggleSelected = onToggleSelected
                 )
+                if (rhythmState.selectedMode == RhythmMode.RHYTHM) {
+                    Image(
+                        imageVector = ImageVector.vectorResource(R.drawable.ic_watch),
+                        contentDescription = null,
+                        modifier = Modifier
+                            .padding(end = 8.dp)
+                            .clickableWithoutRipple { onWatchBtnClick() }
+                            .padding(6.dp)
+                    )
+                }
             }
-        }
 
-        Text(
-            modifier = Modifier
-                .padding(top = 26.dp, start = 60.dp, end = 60.dp)
-                .align(Alignment.CenterHorizontally),
-            text = if (rhythmState.selectedMode == RhythmMode.RHYTHM) {
-                stringResource(R.string.rhythm_tv_title)
-            } else {
-                stringResource(R.string.stretch_tv_title)
-            },
-            textAlign = TextAlign.Center,
-            style = StempoTheme.typography.head1
-        )
+            Text(
+                modifier = Modifier
+                    .padding(top = 26.dp, start = 60.dp, end = 60.dp)
+                    .align(Alignment.CenterHorizontally),
+                text = if (rhythmState.selectedMode == RhythmMode.RHYTHM) {
+                    stringResource(R.string.rhythm_tv_title)
+                } else {
+                    stringResource(R.string.stretch_tv_title)
+                },
+                textAlign = TextAlign.Center,
+                style = StempoTheme.typography.head1
+            )
 
-        Spacer(modifier = Modifier.weight(1f))
+            Spacer(modifier = Modifier.weight(1f))
 
-        if (rhythmState.selectedMode == RhythmMode.RHYTHM) {
+            if (rhythmState.selectedMode == RhythmMode.RHYTHM) {
+                Row(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .padding(bottom = 34.dp)
+                        .clickableWithoutRipple { onChangeBtnClick() },
+                    horizontalArrangement = Arrangement.Center
+                ) {
+                    RhythmChip(
+                        text = stringResource(R.string.rhythm_tv_bit, rhythmState.bit),
+                        color = rhythmState.color,
+                        isFilled = true
+                    )
+                    RhythmChip(
+                        modifier = Modifier.padding(horizontal = 6.dp),
+                        text = stringResource(R.string.rhythm_tv_bpm, rhythmState.bpm),
+                        color = rhythmState.color,
+                    )
+                    RhythmChip(
+                        text = stringResource(R.string.rhythm_tv_step, rhythmState.stepCount),
+                    )
+                }
+            }
+
             Row(
                 modifier = Modifier
                     .fillMaxWidth()
-                    .padding(bottom = 34.dp)
-                    .clickableWithoutRipple { onChangeBtnClick() },
+                    .padding(horizontal = 16.dp)
+                    .padding(bottom = 24.dp)
+                    .clip(RoundedCornerShape(12.dp))
+                    .background(Dark)
+                    .clickableWithoutRipple { onChangeBtnClick() }
+                    .padding(vertical = 15.dp),
+                verticalAlignment = Alignment.CenterVertically,
                 horizontalArrangement = Arrangement.Center
             ) {
-                RhythmChip(
-                    text = stringResource(R.string.rhythm_tv_bit, rhythmState.bit),
-                    color = rhythmState.color,
-                    isFilled = true
+                Image(
+                    imageVector = ImageVector.vectorResource(R.drawable.ic_change),
+                    contentDescription = null,
+                    modifier = Modifier.padding(top = 1.dp)
                 )
-                RhythmChip(
-                    modifier = Modifier.padding(horizontal = 6.dp),
-                    text = stringResource(R.string.rhythm_tv_bpm, rhythmState.bpm),
-                    color = rhythmState.color,
-                )
-                RhythmChip(
-                    text = stringResource(R.string.rhythm_tv_step, rhythmState.stepCount),
+                Text(
+                    text = stringResource(id = R.string.rhythm_btn_change_level),
+                    style = StempoTheme.typography.head4,
+                    color = White
                 )
             }
-        }
-
-        Row(
-            modifier = Modifier
-                .fillMaxWidth()
-                .padding(horizontal = 16.dp)
-                .padding(bottom = 24.dp)
-                .clip(RoundedCornerShape(12.dp))
-                .background(Dark)
-                .clickableWithoutRipple { onChangeBtnClick() }
-                .padding(vertical = 15.dp),
-            verticalAlignment = Alignment.CenterVertically,
-            horizontalArrangement = Arrangement.Center
-        ) {
-            Image(
-                imageVector = ImageVector.vectorResource(R.drawable.ic_change),
-                contentDescription = null,
-                modifier = Modifier.padding(top = 1.dp)
-            )
-            Text(
-                text = stringResource(id = R.string.rhythm_btn_change_level),
-                style = StempoTheme.typography.head4,
-                color = White
-            )
         }
     }
 }

--- a/presentation/src/main/java/com/kkkk/presentation/main/rhythm/RhythmScreen.kt
+++ b/presentation/src/main/java/com/kkkk/presentation/main/rhythm/RhythmScreen.kt
@@ -2,12 +2,12 @@ package com.kkkk.presentation.main.rhythm
 
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
-import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.aspectRatio
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
@@ -22,6 +22,7 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
+import androidx.compose.ui.draw.scale
 import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.res.vectorResource
@@ -35,6 +36,7 @@ import com.airbnb.lottie.compose.LottieConstants
 import com.airbnb.lottie.compose.rememberLottieComposition
 import com.kkkk.presentation.main.rhythm.component.RhythmChip
 import com.kkkk.presentation.main.rhythm.component.RhythmModeToggle
+import com.kkkk.presentation.main.rhythm.component.clickableWithoutRipple
 import com.kkkk.presentation.main.theme.Dark
 import com.kkkk.presentation.main.theme.Purple50
 import com.kkkk.presentation.main.theme.StempoTheme
@@ -71,6 +73,39 @@ internal fun RhythmScreen(
     onStopBtnClick: () -> Unit = {},
     onChangeBtnClick: () -> Unit = {}
 ) {
+    Box(
+        modifier = Modifier.fillMaxSize(),
+        contentAlignment = Alignment.Center
+    ) {
+        Image(
+            imageVector = ImageVector.vectorResource(id = R.drawable.img_rhythm_bg_purple),
+            contentDescription = null,
+            modifier = Modifier
+                .padding(horizontal = 40.dp)
+                .fillMaxWidth()
+                .aspectRatio(1f)
+                .padding(bottom = 10.dp)
+        )
+        Image(
+            imageVector = ImageVector.vectorResource(id = if (!isPlaying) R.drawable.ic_play else R.drawable.ic_stop),
+            contentDescription = null,
+            modifier = Modifier
+                .size(120.dp)
+                .padding(bottom = 10.dp)
+                .clickableWithoutRipple { if (isPlaying) onStopBtnClick() else onPlayBtnClick() }
+        )
+        if (isPlaying) {
+            LottieAnimation(
+                composition = lottieComposition,
+                iterations = LottieConstants.IterateForever,
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .aspectRatio(1f)
+                    .scale(1.5f)
+            )
+        }
+    }
+
     Column(
         modifier = Modifier.fillMaxSize(),
     ) {
@@ -89,7 +124,7 @@ internal fun RhythmScreen(
                     contentDescription = null,
                     modifier = Modifier
                         .padding(end = 8.dp)
-                        .clickable { onWatchBtnClick() }
+                        .clickableWithoutRipple { onWatchBtnClick() }
                         .padding(6.dp)
                 )
             }
@@ -114,7 +149,8 @@ internal fun RhythmScreen(
             Row(
                 modifier = Modifier
                     .fillMaxWidth()
-                    .padding(bottom = 34.dp),
+                    .padding(bottom = 34.dp)
+                    .clickableWithoutRipple { onChangeBtnClick() },
                 horizontalArrangement = Arrangement.Center
             ) {
                 RhythmChip(
@@ -140,7 +176,7 @@ internal fun RhythmScreen(
                 .padding(bottom = 24.dp)
                 .clip(RoundedCornerShape(12.dp))
                 .background(Dark)
-                .clickable { onChangeBtnClick() }
+                .clickableWithoutRipple { onChangeBtnClick() }
                 .padding(vertical = 15.dp),
             verticalAlignment = Alignment.CenterVertically,
             horizontalArrangement = Arrangement.Center
@@ -154,35 +190,6 @@ internal fun RhythmScreen(
                 text = stringResource(id = R.string.rhythm_btn_change_level),
                 style = StempoTheme.typography.head4,
                 color = White
-            )
-        }
-    }
-
-    Box(
-        modifier = Modifier.fillMaxSize(),
-        contentAlignment = Alignment.Center
-    ) {
-        Image(
-            imageVector = ImageVector.vectorResource(id = R.drawable.img_rhythm_bg_purple),
-            contentDescription = null,
-            modifier = Modifier
-                .size(320.dp)
-                .padding(bottom = 10.dp)
-                .background(White)
-        )
-        Image(
-            imageVector = ImageVector.vectorResource(id = if (!isPlaying) R.drawable.ic_play else R.drawable.ic_stop),
-            contentDescription = null,
-            modifier = Modifier
-                .size(120.dp)
-                .padding(bottom = 10.dp)
-                .clickable { if (isPlaying) onStopBtnClick() else onPlayBtnClick() }
-        )
-        if (isPlaying) {
-            LottieAnimation(
-                composition = lottieComposition,
-                iterations = LottieConstants.IterateForever,
-                modifier = Modifier.fillMaxSize()
             )
         }
     }

--- a/presentation/src/main/java/com/kkkk/presentation/main/rhythm/RhythmScreen.kt
+++ b/presentation/src/main/java/com/kkkk/presentation/main/rhythm/RhythmScreen.kt
@@ -26,8 +26,10 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.res.vectorResource
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
+import com.kkkk.presentation.main.rhythm.component.RhythmChip
 import com.kkkk.presentation.main.rhythm.component.RhythmModeToggle
 import com.kkkk.presentation.main.theme.Dark
+import com.kkkk.presentation.main.theme.Purple50
 import com.kkkk.presentation.main.theme.StempoTheme
 import com.kkkk.presentation.main.theme.White
 import com.kkkk.stempo.presentation.R
@@ -64,7 +66,7 @@ internal fun RhythmScreen(
             if (selectedMode == RhythmMode.RHYTHM) {
                 Image(
                     imageVector = ImageVector.vectorResource(R.drawable.ic_watch),
-                    contentDescription = "",
+                    contentDescription = null,
                     modifier = Modifier
                         .padding(end = 8.dp)
                         .clickable { onWatchBtnClick() }
@@ -86,6 +88,27 @@ internal fun RhythmScreen(
         )
 
         Spacer(modifier = Modifier.weight(1f))
+
+        Row(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(bottom = 34.dp),
+            horizontalArrangement = Arrangement.Center
+        ) {
+            RhythmChip(
+                text = "2박자",
+                color = Purple50,
+                isFilled = true
+            )
+            RhythmChip(
+                modifier = Modifier.padding(horizontal = 6.dp),
+                text = "65빠르기",
+                color = Purple50,
+            )
+            RhythmChip(
+                text = "000걸음",
+            )
+        }
 
         Row(
             modifier = Modifier

--- a/presentation/src/main/java/com/kkkk/presentation/main/rhythm/RhythmScreen.kt
+++ b/presentation/src/main/java/com/kkkk/presentation/main/rhythm/RhythmScreen.kt
@@ -106,7 +106,7 @@ internal fun RhythmScreen(
             )
             Text(
                 text = stringResource(id = R.string.rhythm_btn_change_level),
-                style = StempoTheme.typography.head3,
+                style = StempoTheme.typography.head4,
                 color = White
             )
         }

--- a/presentation/src/main/java/com/kkkk/presentation/main/rhythm/RhythmScreen.kt
+++ b/presentation/src/main/java/com/kkkk/presentation/main/rhythm/RhythmScreen.kt
@@ -13,9 +13,12 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Text
+import androidx.compose.material3.rememberModalBottomSheetState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
@@ -41,7 +44,9 @@ import com.kkkk.presentation.main.theme.Dark
 import com.kkkk.presentation.main.theme.StempoTheme
 import com.kkkk.presentation.main.theme.White
 import com.kkkk.stempo.presentation.R
+import kotlinx.coroutines.launch
 
+@OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun RhythmRoute(
     viewModel: RhythmViewModel = hiltViewModel(),
@@ -51,6 +56,9 @@ fun RhythmRoute(
     val lottieComposition by rememberLottieComposition(
         LottieCompositionSpec.RawRes(rhythmState.lottieResource)
     )
+
+    val sheetState = rememberModalBottomSheetState()
+    val scope = rememberCoroutineScope()
 
     RhythmScreen(
         rhythmState = rhythmState,
@@ -64,10 +72,13 @@ fun RhythmRoute(
     if (rhythmState.isBottomSheetVisible) {
         RhythmBottomSheet(
             rhythmState = rhythmState,
+            sheetState = sheetState,
             onDismissRequest = { viewModel.showBottomSheet(false) },
             onSubmitBtnClick = { bit, bpm ->
-                viewModel.updateRhythm(bit, bpm)
-                viewModel.showBottomSheet(false)
+                scope.launch { sheetState.hide() }.invokeOnCompletion {
+                    viewModel.updateRhythm(bit, bpm)
+                    viewModel.showBottomSheet(false)
+                }
             }
         )
     }

--- a/presentation/src/main/java/com/kkkk/presentation/main/rhythm/RhythmScreen.kt
+++ b/presentation/src/main/java/com/kkkk/presentation/main/rhythm/RhythmScreen.kt
@@ -11,6 +11,7 @@ import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
@@ -47,8 +48,11 @@ fun RhythmRoute() {
 @Composable
 internal fun RhythmScreen(
     selectedMode: RhythmMode,
+    isPlaying: Boolean = false,
     onToggleSelected: (RhythmMode) -> Unit = {},
     onWatchBtnClick: () -> Unit = {},
+    onPlayBtnClick: () -> Unit = {},
+    onStopBtnClick: () -> Unit = {},
     onChangeBtnClick: () -> Unit = {}
 ) {
     Column(
@@ -133,6 +137,39 @@ internal fun RhythmScreen(
                 color = White
             )
         }
+    }
+
+    Box(
+        modifier = Modifier.fillMaxSize(),
+        contentAlignment = Alignment.Center
+    ) {
+        Image(
+            imageVector = ImageVector.vectorResource(id = R.drawable.img_rhythm_bg_purple),
+            contentDescription = null,
+            modifier = Modifier
+                .size(320.dp)
+                .padding(bottom = 10.dp)
+        )
+        Image(
+            imageVector = ImageVector.vectorResource(id = if (!isPlaying) R.drawable.ic_play else R.drawable.ic_stop),
+            contentDescription = null,
+            modifier = Modifier
+                .size(120.dp)
+                .padding(bottom = 10.dp)
+                .clickable { if(isPlaying) onStopBtnClick() else onPlayBtnClick() }
+        )
+
+//        val lottieComposition by rememberLottieComposition(
+//            LottieCompositionSpec.RawRes(R.raw.stempo_rhythm_purple)
+//        )
+//
+//        if (isPlaying) {
+//            LottieAnimation(
+//                composition = lottieComposition,
+//                iterations = LottieConstants.IterateForever,
+//                modifier = Modifier.size(520.dp)
+//            )
+//        }
     }
 }
 

--- a/presentation/src/main/java/com/kkkk/presentation/main/rhythm/RhythmScreen.kt
+++ b/presentation/src/main/java/com/kkkk/presentation/main/rhythm/RhythmScreen.kt
@@ -1,27 +1,72 @@
 package com.kkkk.presentation.main.rhythm
 
+import androidx.compose.foundation.Image
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.padding
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.res.vectorResource
 import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import com.kkkk.presentation.main.rhythm.component.RhythmModeToggle
+import com.kkkk.presentation.main.theme.StempoTheme
+import com.kkkk.stempo.presentation.R
 
 @Composable
 fun RhythmRoute() {
-    RhythmScreen()
+    var selectedMode by remember { mutableStateOf(RhythmMode.RHYTHM) }
+
+    RhythmScreen(
+        selectedMode = selectedMode,
+        onToggleSelected = { selectedMode = it }
+    )
 }
 
 @Composable
-internal fun RhythmScreen() {
+internal fun RhythmScreen(
+    selectedMode: RhythmMode,
+    onToggleSelected: (RhythmMode) -> Unit = {},
+    onWatchBtnClick: () -> Unit = {},
+) {
     Column(
         modifier = Modifier.fillMaxSize(),
     ) {
-
+        Box(
+            modifier = Modifier.padding(top = 24.dp),
+            contentAlignment = Alignment.CenterEnd
+        ) {
+            RhythmModeToggle(
+                modifier = Modifier.padding(horizontal = 60.dp),
+                selectedMode = selectedMode,
+                onToggleSelected = onToggleSelected
+            )
+            if (selectedMode == RhythmMode.RHYTHM) {
+                Image(
+                    imageVector = ImageVector.vectorResource(R.drawable.ic_watch),
+                    contentDescription = "",
+                    modifier = Modifier
+                        .padding(end = 8.dp)
+                        .clickable { onWatchBtnClick() }
+                        .padding(6.dp)
+                )
+            }
+        }
     }
 }
 
 @Preview(showBackground = true)
 @Composable
 fun RhythmScreenPreview() {
-    RhythmScreen()
+    StempoTheme {
+        RhythmScreen(selectedMode = RhythmMode.RHYTHM)
+    }
 }

--- a/presentation/src/main/java/com/kkkk/presentation/main/rhythm/RhythmScreen.kt
+++ b/presentation/src/main/java/com/kkkk/presentation/main/rhythm/RhythmScreen.kt
@@ -1,11 +1,18 @@
 package com.kkkk.presentation.main.rhythm
 
 import androidx.compose.foundation.Image
+import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
@@ -13,12 +20,16 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.res.vectorResource
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import com.kkkk.presentation.main.rhythm.component.RhythmModeToggle
+import com.kkkk.presentation.main.theme.Dark
 import com.kkkk.presentation.main.theme.StempoTheme
+import com.kkkk.presentation.main.theme.White
 import com.kkkk.stempo.presentation.R
 
 @Composable
@@ -36,6 +47,7 @@ internal fun RhythmScreen(
     selectedMode: RhythmMode,
     onToggleSelected: (RhythmMode) -> Unit = {},
     onWatchBtnClick: () -> Unit = {},
+    onChangeBtnClick: () -> Unit = {}
 ) {
     Column(
         modifier = Modifier.fillMaxSize(),
@@ -59,6 +71,44 @@ internal fun RhythmScreen(
                         .padding(6.dp)
                 )
             }
+        }
+
+        Text(
+            modifier = Modifier
+                .padding(top = 26.dp, start = 60.dp, end = 60.dp)
+                .align(Alignment.CenterHorizontally),
+            text = if (selectedMode == RhythmMode.RHYTHM) {
+                stringResource(R.string.rhythm_tv_title)
+            } else {
+                stringResource(R.string.stretch_tv_title)
+            },
+            style = StempoTheme.typography.head1
+        )
+
+        Spacer(modifier = Modifier.weight(1f))
+
+        Row(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(horizontal = 16.dp)
+                .padding(bottom = 24.dp)
+                .clip(RoundedCornerShape(12.dp))
+                .background(Dark)
+                .clickable { onChangeBtnClick() }
+                .padding(vertical = 15.dp),
+            verticalAlignment = Alignment.CenterVertically,
+            horizontalArrangement = Arrangement.Center
+        ) {
+            Image(
+                imageVector = ImageVector.vectorResource(R.drawable.ic_change),
+                contentDescription = null,
+                modifier = Modifier.padding(top = 1.dp)
+            )
+            Text(
+                text = stringResource(id = R.string.rhythm_btn_change_level),
+                style = StempoTheme.typography.head3,
+                color = White
+            )
         }
     }
 }

--- a/presentation/src/main/java/com/kkkk/presentation/main/rhythm/RhythmScreen.kt
+++ b/presentation/src/main/java/com/kkkk/presentation/main/rhythm/RhythmScreen.kt
@@ -5,6 +5,7 @@ import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.ColumnScope
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.aspectRatio
@@ -107,33 +108,13 @@ internal fun RhythmScreen(
         modifier = Modifier.fillMaxSize(),
         contentAlignment = Alignment.Center
     ) {
-        Image(
-            imageVector = ImageVector.vectorResource(id = rhythmState.imageResource),
-            contentDescription = null,
-            modifier = Modifier
-                .padding(horizontal = 40.dp)
-                .fillMaxWidth()
-                .aspectRatio(1f)
-                .padding(bottom = 10.dp)
+        RhythmPlayBtnWithLottie(
+            rhythmState = rhythmState,
+            lottieComposition = lottieComposition,
+            onPlayBtnClick = onPlayBtnClick,
+            onStopBtnClick = onStopBtnClick
         )
-        Image(
-            imageVector = ImageVector.vectorResource(id = if (!rhythmState.isPlaying) R.drawable.ic_play else R.drawable.ic_stop),
-            contentDescription = null,
-            modifier = Modifier
-                .size(120.dp)
-                .padding(bottom = 10.dp)
-                .clickableWithoutRipple { if (rhythmState.isPlaying) onStopBtnClick() else onPlayBtnClick() }
-        )
-        if (rhythmState.isPlaying) {
-            LottieAnimation(
-                composition = lottieComposition,
-                iterations = LottieConstants.IterateForever,
-                modifier = Modifier
-                    .fillMaxWidth()
-                    .aspectRatio(1f)
-                    .scale(1.5f)
-            )
-        }
+
         Column(
             modifier = Modifier.fillMaxSize(),
         ) {
@@ -146,81 +127,154 @@ internal fun RhythmScreen(
                     selectedMode = rhythmState.selectedMode,
                     onToggleSelected = onToggleSelected
                 )
+
                 if (rhythmState.selectedMode == RhythmMode.RHYTHM) {
-                    Image(
-                        imageVector = ImageVector.vectorResource(R.drawable.ic_watch),
-                        contentDescription = null,
-                        modifier = Modifier
-                            .padding(end = 8.dp)
-                            .clickableWithoutRipple { onWatchBtnClick() }
-                            .padding(6.dp)
-                    )
+                    WatchSyncBtn(onWatchBtnClick)
                 }
             }
 
-            Text(
-                modifier = Modifier
-                    .padding(top = 26.dp, start = 60.dp, end = 60.dp)
-                    .align(Alignment.CenterHorizontally),
-                text = if (rhythmState.selectedMode == RhythmMode.RHYTHM) {
-                    stringResource(R.string.rhythm_tv_title)
-                } else {
-                    stringResource(R.string.stretch_tv_title)
-                },
-                textAlign = TextAlign.Center,
-                style = StempoTheme.typography.head1
+            RhythmTitleText(
+                rhythmState = rhythmState
             )
 
             Spacer(modifier = Modifier.weight(1f))
 
             if (rhythmState.selectedMode == RhythmMode.RHYTHM) {
-                Row(
-                    modifier = Modifier
-                        .fillMaxWidth()
-                        .padding(bottom = 34.dp)
-                        .clickableWithoutRipple { onChangeBtnClick() },
-                    horizontalArrangement = Arrangement.Center
-                ) {
-                    RhythmChip(
-                        text = stringResource(R.string.rhythm_tv_bit, rhythmState.bit),
-                        color = rhythmState.color,
-                        isFilled = true
-                    )
-                    RhythmChip(
-                        modifier = Modifier.padding(horizontal = 6.dp),
-                        text = stringResource(R.string.rhythm_tv_bpm, rhythmState.bpm),
-                        color = rhythmState.color,
-                    )
-                    RhythmChip(
-                        text = stringResource(R.string.rhythm_tv_step, rhythmState.stepCount),
-                    )
-                }
+                RhythmInfoChips(
+                    rhythmState = rhythmState,
+                    onChangeBtnClick = onChangeBtnClick
+                )
             }
 
-            Row(
-                modifier = Modifier
-                    .fillMaxWidth()
-                    .padding(horizontal = 16.dp)
-                    .padding(bottom = 24.dp)
-                    .clip(RoundedCornerShape(12.dp))
-                    .background(Dark)
-                    .clickableWithoutRipple { onChangeBtnClick() }
-                    .padding(vertical = 15.dp),
-                verticalAlignment = Alignment.CenterVertically,
-                horizontalArrangement = Arrangement.Center
-            ) {
-                Image(
-                    imageVector = ImageVector.vectorResource(R.drawable.ic_change),
-                    contentDescription = null,
-                    modifier = Modifier.padding(top = 1.dp)
-                )
-                Text(
-                    text = stringResource(id = R.string.rhythm_btn_change_level),
-                    style = StempoTheme.typography.head4,
-                    color = White
-                )
-            }
+            RhythmChangeBtn(
+                onChangeBtnClick = onChangeBtnClick
+            )
         }
+    }
+}
+
+@Composable
+fun RhythmPlayBtnWithLottie(
+    rhythmState: RhythmState,
+    lottieComposition: LottieComposition?,
+    onPlayBtnClick: () -> Unit = {},
+    onStopBtnClick: () -> Unit = {}
+) {
+    Image(
+        imageVector = ImageVector.vectorResource(id = rhythmState.imageResource),
+        contentDescription = null,
+        modifier = Modifier
+            .padding(horizontal = 40.dp)
+            .fillMaxWidth()
+            .aspectRatio(1f)
+            .padding(bottom = 10.dp)
+    )
+    Image(
+        imageVector = ImageVector.vectorResource(id = if (!rhythmState.isPlaying) R.drawable.ic_play else R.drawable.ic_stop),
+        contentDescription = null,
+        modifier = Modifier
+            .size(120.dp)
+            .padding(bottom = 10.dp)
+            .clickableWithoutRipple { if (rhythmState.isPlaying) onStopBtnClick() else onPlayBtnClick() }
+    )
+    if (rhythmState.isPlaying) {
+        LottieAnimation(
+            composition = lottieComposition,
+            iterations = LottieConstants.IterateForever,
+            modifier = Modifier
+                .fillMaxWidth()
+                .aspectRatio(1f)
+                .scale(1.5f)
+        )
+    }
+}
+
+@Composable
+fun WatchSyncBtn(
+    onWatchBtnClick: () -> Unit = {}
+) {
+    Image(
+        imageVector = ImageVector.vectorResource(R.drawable.ic_watch),
+        contentDescription = null,
+        modifier = Modifier
+            .padding(end = 8.dp)
+            .clickableWithoutRipple { onWatchBtnClick() }
+            .padding(6.dp)
+    )
+}
+
+@Composable
+fun ColumnScope.RhythmTitleText(
+    rhythmState: RhythmState
+) {
+    Text(
+        modifier = Modifier
+            .padding(top = 26.dp, start = 60.dp, end = 60.dp)
+            .align(Alignment.CenterHorizontally),
+        text = if (rhythmState.selectedMode == RhythmMode.RHYTHM) {
+            stringResource(R.string.rhythm_tv_title)
+        } else {
+            stringResource(R.string.stretch_tv_title)
+        },
+        textAlign = TextAlign.Center,
+        style = StempoTheme.typography.head1
+    )
+}
+
+@Composable
+fun ColumnScope.RhythmInfoChips(
+    rhythmState: RhythmState,
+    onChangeBtnClick: () -> Unit = {}
+) {
+    Row(
+        modifier = Modifier
+            .padding(bottom = 34.dp)
+            .align(Alignment.CenterHorizontally)
+            .clickableWithoutRipple { onChangeBtnClick() },
+        horizontalArrangement = Arrangement.Center
+    ) {
+        RhythmChip(
+            text = stringResource(R.string.rhythm_tv_bit, rhythmState.bit),
+            color = rhythmState.color,
+            isFilled = true
+        )
+        RhythmChip(
+            modifier = Modifier.padding(horizontal = 6.dp),
+            text = stringResource(R.string.rhythm_tv_bpm, rhythmState.bpm),
+            color = rhythmState.color,
+        )
+        RhythmChip(
+            text = stringResource(R.string.rhythm_tv_step, rhythmState.stepCount),
+        )
+    }
+}
+
+@Composable
+fun RhythmChangeBtn(
+    onChangeBtnClick: () -> Unit = {}
+) {
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(horizontal = 16.dp)
+            .padding(bottom = 24.dp)
+            .clip(RoundedCornerShape(12.dp))
+            .background(Dark)
+            .clickableWithoutRipple { onChangeBtnClick() }
+            .padding(vertical = 15.dp),
+        verticalAlignment = Alignment.CenterVertically,
+        horizontalArrangement = Arrangement.Center
+    ) {
+        Image(
+            imageVector = ImageVector.vectorResource(R.drawable.ic_change),
+            contentDescription = null,
+            modifier = Modifier.padding(top = 1.dp)
+        )
+        Text(
+            text = stringResource(id = R.string.rhythm_btn_change_level),
+            style = StempoTheme.typography.head4,
+            color = White
+        )
     }
 }
 

--- a/presentation/src/main/java/com/kkkk/presentation/main/rhythm/RhythmScreen.kt
+++ b/presentation/src/main/java/com/kkkk/presentation/main/rhythm/RhythmScreen.kt
@@ -16,9 +16,6 @@ import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableStateOf
-import androidx.compose.runtime.remember
-import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
@@ -29,6 +26,8 @@ import androidx.compose.ui.res.vectorResource
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
+import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.airbnb.lottie.LottieComposition
 import com.airbnb.lottie.compose.LottieAnimation
 import com.airbnb.lottie.compose.LottieCompositionSpec
@@ -38,35 +37,33 @@ import com.kkkk.presentation.main.rhythm.component.RhythmChip
 import com.kkkk.presentation.main.rhythm.component.RhythmModeToggle
 import com.kkkk.presentation.main.rhythm.component.clickableWithoutRipple
 import com.kkkk.presentation.main.theme.Dark
-import com.kkkk.presentation.main.theme.Purple50
 import com.kkkk.presentation.main.theme.StempoTheme
 import com.kkkk.presentation.main.theme.White
 import com.kkkk.stempo.presentation.R
 
 @Composable
-fun RhythmRoute() {
-    var selectedMode by remember { mutableStateOf(RhythmMode.RHYTHM) }
-    var isPlaying by remember { mutableStateOf(false) }
+fun RhythmRoute(
+    viewModel: RhythmViewModel = hiltViewModel(),
+) {
+    val rhythmState by viewModel.rhythmState.collectAsStateWithLifecycle()
 
     val lottieComposition by rememberLottieComposition(
-        LottieCompositionSpec.RawRes(R.raw.stempo_rhythm_purple)
+        LottieCompositionSpec.RawRes(rhythmState.lottieResource)
     )
 
     RhythmScreen(
-        selectedMode = selectedMode,
+        rhythmState = rhythmState,
         lottieComposition = lottieComposition,
-        isPlaying = isPlaying,
-        onToggleSelected = { selectedMode = it },
-        onPlayBtnClick = { isPlaying = true },
-        onStopBtnClick = { isPlaying = false }
+        onToggleSelected = viewModel::changeSelectedMode,
+        onPlayBtnClick = viewModel::changeIsPlaying,
+        onStopBtnClick = viewModel::changeIsPlaying,
     )
 }
 
 @Composable
 internal fun RhythmScreen(
-    selectedMode: RhythmMode,
+    rhythmState: RhythmState,
     lottieComposition: LottieComposition?,
-    isPlaying: Boolean = false,
     onToggleSelected: (RhythmMode) -> Unit = {},
     onWatchBtnClick: () -> Unit = {},
     onPlayBtnClick: () -> Unit = {},
@@ -78,7 +75,7 @@ internal fun RhythmScreen(
         contentAlignment = Alignment.Center
     ) {
         Image(
-            imageVector = ImageVector.vectorResource(id = R.drawable.img_rhythm_bg_purple),
+            imageVector = ImageVector.vectorResource(id = rhythmState.imageResource),
             contentDescription = null,
             modifier = Modifier
                 .padding(horizontal = 40.dp)
@@ -87,14 +84,14 @@ internal fun RhythmScreen(
                 .padding(bottom = 10.dp)
         )
         Image(
-            imageVector = ImageVector.vectorResource(id = if (!isPlaying) R.drawable.ic_play else R.drawable.ic_stop),
+            imageVector = ImageVector.vectorResource(id = if (!rhythmState.isPlaying) R.drawable.ic_play else R.drawable.ic_stop),
             contentDescription = null,
             modifier = Modifier
                 .size(120.dp)
                 .padding(bottom = 10.dp)
-                .clickableWithoutRipple { if (isPlaying) onStopBtnClick() else onPlayBtnClick() }
+                .clickableWithoutRipple { if (rhythmState.isPlaying) onStopBtnClick() else onPlayBtnClick() }
         )
-        if (isPlaying) {
+        if (rhythmState.isPlaying) {
             LottieAnimation(
                 composition = lottieComposition,
                 iterations = LottieConstants.IterateForever,
@@ -115,10 +112,10 @@ internal fun RhythmScreen(
         ) {
             RhythmModeToggle(
                 modifier = Modifier.padding(horizontal = 60.dp),
-                selectedMode = selectedMode,
+                selectedMode = rhythmState.selectedMode,
                 onToggleSelected = onToggleSelected
             )
-            if (selectedMode == RhythmMode.RHYTHM) {
+            if (rhythmState.selectedMode == RhythmMode.RHYTHM) {
                 Image(
                     imageVector = ImageVector.vectorResource(R.drawable.ic_watch),
                     contentDescription = null,
@@ -134,7 +131,7 @@ internal fun RhythmScreen(
             modifier = Modifier
                 .padding(top = 26.dp, start = 60.dp, end = 60.dp)
                 .align(Alignment.CenterHorizontally),
-            text = if (selectedMode == RhythmMode.RHYTHM) {
+            text = if (rhythmState.selectedMode == RhythmMode.RHYTHM) {
                 stringResource(R.string.rhythm_tv_title)
             } else {
                 stringResource(R.string.stretch_tv_title)
@@ -145,7 +142,7 @@ internal fun RhythmScreen(
 
         Spacer(modifier = Modifier.weight(1f))
 
-        if (selectedMode == RhythmMode.RHYTHM) {
+        if (rhythmState.selectedMode == RhythmMode.RHYTHM) {
             Row(
                 modifier = Modifier
                     .fillMaxWidth()
@@ -154,17 +151,17 @@ internal fun RhythmScreen(
                 horizontalArrangement = Arrangement.Center
             ) {
                 RhythmChip(
-                    text = "2박자",
-                    color = Purple50,
+                    text = stringResource(R.string.rhythm_tv_bit, rhythmState.bit),
+                    color = rhythmState.color,
                     isFilled = true
                 )
                 RhythmChip(
                     modifier = Modifier.padding(horizontal = 6.dp),
-                    text = "65빠르기",
-                    color = Purple50,
+                    text = stringResource(R.string.rhythm_tv_bpm, rhythmState.bpm),
+                    color = rhythmState.color,
                 )
                 RhythmChip(
-                    text = "000걸음",
+                    text = stringResource(R.string.rhythm_tv_step, rhythmState.stepCount),
                 )
             }
         }
@@ -200,7 +197,7 @@ internal fun RhythmScreen(
 fun RhythmScreenPreview() {
     StempoTheme {
         RhythmScreen(
-            selectedMode = RhythmMode.RHYTHM,
+            rhythmState = RhythmState(),
             lottieComposition = null
         )
     }

--- a/presentation/src/main/java/com/kkkk/presentation/main/rhythm/RhythmScreen.kt
+++ b/presentation/src/main/java/com/kkkk/presentation/main/rhythm/RhythmScreen.kt
@@ -33,6 +33,7 @@ import com.airbnb.lottie.compose.LottieAnimation
 import com.airbnb.lottie.compose.LottieCompositionSpec
 import com.airbnb.lottie.compose.LottieConstants
 import com.airbnb.lottie.compose.rememberLottieComposition
+import com.kkkk.presentation.main.rhythm.component.RhythmBottomSheet
 import com.kkkk.presentation.main.rhythm.component.RhythmChip
 import com.kkkk.presentation.main.rhythm.component.RhythmModeToggle
 import com.kkkk.presentation.main.rhythm.component.clickableWithoutRipple
@@ -57,7 +58,19 @@ fun RhythmRoute(
         onToggleSelected = viewModel::changeSelectedMode,
         onPlayBtnClick = viewModel::changeIsPlaying,
         onStopBtnClick = viewModel::changeIsPlaying,
+        onChangeBtnClick = { viewModel.showBottomSheet(true) }
     )
+
+    if (rhythmState.isBottomSheetVisible) {
+        RhythmBottomSheet(
+            rhythmState = rhythmState,
+            onDismissRequest = { viewModel.showBottomSheet(false) },
+            onSubmitBtnClick = { bit, bpm ->
+                viewModel.updateRhythm(bit, bpm)
+                viewModel.showBottomSheet(false)
+            }
+        )
+    }
 }
 
 @Composable

--- a/presentation/src/main/java/com/kkkk/presentation/main/rhythm/RhythmScreen.kt
+++ b/presentation/src/main/java/com/kkkk/presentation/main/rhythm/RhythmScreen.kt
@@ -25,8 +25,14 @@ import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.res.vectorResource
+import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
+import com.airbnb.lottie.LottieComposition
+import com.airbnb.lottie.compose.LottieAnimation
+import com.airbnb.lottie.compose.LottieCompositionSpec
+import com.airbnb.lottie.compose.LottieConstants
+import com.airbnb.lottie.compose.rememberLottieComposition
 import com.kkkk.presentation.main.rhythm.component.RhythmChip
 import com.kkkk.presentation.main.rhythm.component.RhythmModeToggle
 import com.kkkk.presentation.main.theme.Dark
@@ -38,16 +44,26 @@ import com.kkkk.stempo.presentation.R
 @Composable
 fun RhythmRoute() {
     var selectedMode by remember { mutableStateOf(RhythmMode.RHYTHM) }
+    var isPlaying by remember { mutableStateOf(false) }
+
+    val lottieComposition by rememberLottieComposition(
+        LottieCompositionSpec.RawRes(R.raw.stempo_rhythm_purple)
+    )
 
     RhythmScreen(
         selectedMode = selectedMode,
-        onToggleSelected = { selectedMode = it }
+        lottieComposition = lottieComposition,
+        isPlaying = isPlaying,
+        onToggleSelected = { selectedMode = it },
+        onPlayBtnClick = { isPlaying = true },
+        onStopBtnClick = { isPlaying = false }
     )
 }
 
 @Composable
 internal fun RhythmScreen(
     selectedMode: RhythmMode,
+    lottieComposition: LottieComposition?,
     isPlaying: Boolean = false,
     onToggleSelected: (RhythmMode) -> Unit = {},
     onWatchBtnClick: () -> Unit = {},
@@ -88,30 +104,33 @@ internal fun RhythmScreen(
             } else {
                 stringResource(R.string.stretch_tv_title)
             },
+            textAlign = TextAlign.Center,
             style = StempoTheme.typography.head1
         )
 
         Spacer(modifier = Modifier.weight(1f))
 
-        Row(
-            modifier = Modifier
-                .fillMaxWidth()
-                .padding(bottom = 34.dp),
-            horizontalArrangement = Arrangement.Center
-        ) {
-            RhythmChip(
-                text = "2박자",
-                color = Purple50,
-                isFilled = true
-            )
-            RhythmChip(
-                modifier = Modifier.padding(horizontal = 6.dp),
-                text = "65빠르기",
-                color = Purple50,
-            )
-            RhythmChip(
-                text = "000걸음",
-            )
+        if (selectedMode == RhythmMode.RHYTHM) {
+            Row(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(bottom = 34.dp),
+                horizontalArrangement = Arrangement.Center
+            ) {
+                RhythmChip(
+                    text = "2박자",
+                    color = Purple50,
+                    isFilled = true
+                )
+                RhythmChip(
+                    modifier = Modifier.padding(horizontal = 6.dp),
+                    text = "65빠르기",
+                    color = Purple50,
+                )
+                RhythmChip(
+                    text = "000걸음",
+                )
+            }
         }
 
         Row(
@@ -149,6 +168,7 @@ internal fun RhythmScreen(
             modifier = Modifier
                 .size(320.dp)
                 .padding(bottom = 10.dp)
+                .background(White)
         )
         Image(
             imageVector = ImageVector.vectorResource(id = if (!isPlaying) R.drawable.ic_play else R.drawable.ic_stop),
@@ -156,20 +176,15 @@ internal fun RhythmScreen(
             modifier = Modifier
                 .size(120.dp)
                 .padding(bottom = 10.dp)
-                .clickable { if(isPlaying) onStopBtnClick() else onPlayBtnClick() }
+                .clickable { if (isPlaying) onStopBtnClick() else onPlayBtnClick() }
         )
-
-//        val lottieComposition by rememberLottieComposition(
-//            LottieCompositionSpec.RawRes(R.raw.stempo_rhythm_purple)
-//        )
-//
-//        if (isPlaying) {
-//            LottieAnimation(
-//                composition = lottieComposition,
-//                iterations = LottieConstants.IterateForever,
-//                modifier = Modifier.size(520.dp)
-//            )
-//        }
+        if (isPlaying) {
+            LottieAnimation(
+                composition = lottieComposition,
+                iterations = LottieConstants.IterateForever,
+                modifier = Modifier.fillMaxSize()
+            )
+        }
     }
 }
 
@@ -177,6 +192,9 @@ internal fun RhythmScreen(
 @Composable
 fun RhythmScreenPreview() {
     StempoTheme {
-        RhythmScreen(selectedMode = RhythmMode.RHYTHM)
+        RhythmScreen(
+            selectedMode = RhythmMode.RHYTHM,
+            lottieComposition = null
+        )
     }
 }

--- a/presentation/src/main/java/com/kkkk/presentation/main/rhythm/RhythmScreen.kt
+++ b/presentation/src/main/java/com/kkkk/presentation/main/rhythm/RhythmScreen.kt
@@ -1,11 +1,10 @@
 package com.kkkk.presentation.main.rhythm
 
-import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxSize
-import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
-import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.tooling.preview.Preview
 
 @Composable
 fun RhythmRoute() {
@@ -14,10 +13,15 @@ fun RhythmRoute() {
 
 @Composable
 internal fun RhythmScreen() {
-    Box(
+    Column(
         modifier = Modifier.fillMaxSize(),
-        contentAlignment = Alignment.Center
     ) {
-        Text(text = "Rhythm Screen")
+
     }
+}
+
+@Preview(showBackground = true)
+@Composable
+fun RhythmScreenPreview() {
+    RhythmScreen()
 }

--- a/presentation/src/main/java/com/kkkk/presentation/main/rhythm/RhythmState.kt
+++ b/presentation/src/main/java/com/kkkk/presentation/main/rhythm/RhythmState.kt
@@ -1,0 +1,51 @@
+package com.kkkk.presentation.main.rhythm
+
+import androidx.compose.ui.graphics.Color
+import com.kkkk.presentation.main.theme.Green50
+import com.kkkk.presentation.main.theme.Purple50
+import com.kkkk.presentation.main.theme.Sky50
+import com.kkkk.stempo.presentation.R
+
+data class RhythmState(
+    val selectedMode: RhythmMode = RhythmMode.RHYTHM,
+    val isPlaying: Boolean = false,
+    val bit: Int = MIN_BIT,
+    val bpm: Int = MIN_BPM,
+    val stepCount: Int = 0
+) {
+    val filename: String
+        get() = "stempo_bpm_${bpm}_bit_${bit}"
+
+    val color: Color
+        get() = when (bit) {
+            2 -> Purple50
+            3 -> Sky50
+            4 -> Green50
+            6 -> Purple50
+            else -> Sky50
+        }
+
+    val lottieResource: Int
+        get() = when (color) {
+            Purple50 -> R.raw.stempo_rhythm_purple
+            Sky50 -> R.raw.stempo_rhythm_sky
+            Green50 -> R.raw.stempo_rhythm_green
+            else -> R.raw.stempo_rhythm_purple
+        }
+
+    val imageResource: Int
+        get() = when (color) {
+            Purple50 -> R.drawable.img_rhythm_bg_purple
+            Sky50 -> R.drawable.img_rhythm_bg_sky
+            Green50 -> R.drawable.img_rhythm_bg_green
+            else -> R.drawable.img_rhythm_bg_purple
+        }
+
+
+    companion object {
+        const val MIN_BPM = 60
+        const val MAX_BPM = 120
+        const val MIN_BIT = 2
+        const val MAX_BIT = 8
+    }
+}

--- a/presentation/src/main/java/com/kkkk/presentation/main/rhythm/RhythmState.kt
+++ b/presentation/src/main/java/com/kkkk/presentation/main/rhythm/RhythmState.kt
@@ -9,6 +9,7 @@ import com.kkkk.stempo.presentation.R
 data class RhythmState(
     val selectedMode: RhythmMode = RhythmMode.RHYTHM,
     val isPlaying: Boolean = false,
+    val isBottomSheetVisible: Boolean = false,
     val bit: Int = MIN_BIT,
     val bpm: Int = MIN_BPM,
     val stepCount: Int = 0

--- a/presentation/src/main/java/com/kkkk/presentation/main/rhythm/RhythmViewModel.kt
+++ b/presentation/src/main/java/com/kkkk/presentation/main/rhythm/RhythmViewModel.kt
@@ -36,4 +36,12 @@ constructor(
             it.copy(isPlaying = !_rhythmState.value.isPlaying)
         }
     }
+
+    fun showBottomSheet(show: Boolean) {
+        _rhythmState.update { it.copy(isBottomSheetVisible = show) }
+    }
+
+    fun updateRhythm(bit: Int, bpm: Int) {
+        _rhythmState.update { it.copy(bit = bit, bpm = bpm) }
+    }
 }

--- a/presentation/src/main/java/com/kkkk/presentation/main/rhythm/RhythmViewModel.kt
+++ b/presentation/src/main/java/com/kkkk/presentation/main/rhythm/RhythmViewModel.kt
@@ -1,0 +1,39 @@
+package com.kkkk.presentation.main.rhythm
+
+import androidx.lifecycle.ViewModel
+import com.kkkk.domain.repository.RhythmRepository
+import com.kkkk.domain.repository.UserRepository
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.update
+import javax.inject.Inject
+
+@HiltViewModel
+class RhythmViewModel
+@Inject
+constructor(
+    private val rhythmRepository: RhythmRepository,
+    private val userRepository: UserRepository,
+) : ViewModel() {
+    private val _rhythmState = MutableStateFlow(RhythmState())
+    val rhythmState = _rhythmState.asStateFlow()
+
+    fun changeSelectedMode(currentMode: RhythmMode) {
+        _rhythmState.update {
+            it.copy(
+                selectedMode = if (currentMode == RhythmMode.RHYTHM) {
+                    RhythmMode.STRETCH
+                } else {
+                    RhythmMode.RHYTHM
+                }
+            )
+        }
+    }
+
+    fun changeIsPlaying() {
+        _rhythmState.update {
+            it.copy(isPlaying = !_rhythmState.value.isPlaying)
+        }
+    }
+}

--- a/presentation/src/main/java/com/kkkk/presentation/main/rhythm/RhythmViewModel.kt
+++ b/presentation/src/main/java/com/kkkk/presentation/main/rhythm/RhythmViewModel.kt
@@ -19,15 +19,9 @@ constructor(
     private val _rhythmState = MutableStateFlow(RhythmState())
     val rhythmState = _rhythmState.asStateFlow()
 
-    fun changeSelectedMode(currentMode: RhythmMode) {
+    fun changeSelectedMode(selectedMode: RhythmMode) {
         _rhythmState.update {
-            it.copy(
-                selectedMode = if (currentMode == RhythmMode.RHYTHM) {
-                    RhythmMode.STRETCH
-                } else {
-                    RhythmMode.RHYTHM
-                }
-            )
+            it.copy(selectedMode = selectedMode)
         }
     }
 

--- a/presentation/src/main/java/com/kkkk/presentation/main/rhythm/component/ModifierExt.kt
+++ b/presentation/src/main/java/com/kkkk/presentation/main/rhythm/component/ModifierExt.kt
@@ -8,9 +8,11 @@ import androidx.compose.ui.Modifier
 
 @Composable
 fun Modifier.clickableWithoutRipple(
+    enabled: Boolean = true,
     onClick: () -> Unit
 ): Modifier = this.then(
     Modifier.clickable(
+        enabled = enabled,
         indication = null,
         interactionSource = remember { MutableInteractionSource() }
     ) {

--- a/presentation/src/main/java/com/kkkk/presentation/main/rhythm/component/ModifierExt.kt
+++ b/presentation/src/main/java/com/kkkk/presentation/main/rhythm/component/ModifierExt.kt
@@ -1,0 +1,19 @@
+package com.kkkk.presentation.main.rhythm.component
+
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.interaction.MutableInteractionSource
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Modifier
+
+@Composable
+fun Modifier.clickableWithoutRipple(
+    onClick: () -> Unit
+): Modifier = this.then(
+    Modifier.clickable(
+        indication = null,
+        interactionSource = remember { MutableInteractionSource() }
+    ) {
+        onClick()
+    }
+)

--- a/presentation/src/main/java/com/kkkk/presentation/main/rhythm/component/RhythmBitItem.kt
+++ b/presentation/src/main/java/com/kkkk/presentation/main/rhythm/component/RhythmBitItem.kt
@@ -1,0 +1,40 @@
+package com.kkkk.presentation.main.rhythm.component
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.unit.dp
+import com.kkkk.presentation.main.theme.Gray200
+import com.kkkk.presentation.main.theme.Gray600
+import com.kkkk.presentation.main.theme.Purple50
+import com.kkkk.presentation.main.theme.StempoTheme
+import com.kkkk.presentation.main.theme.White
+
+@Composable
+fun RhythmBitItem(
+    bit: Int,
+    isSelected: Boolean,
+    onBitClick: () -> Unit = {}
+) {
+    Box(
+        modifier = Modifier
+            .padding(8.dp)
+            .clip(RoundedCornerShape(17.dp))
+            .background(if (isSelected) Purple50 else Gray200)
+            .clickableWithoutRipple { onBitClick() }
+            .padding(vertical = 12.dp),
+        contentAlignment = Alignment.Center
+    ) {
+        Text(
+            text = "$bit 박자",
+            style = StempoTheme.typography.head2,
+            color = if (isSelected) White else Gray600
+        )
+    }
+}

--- a/presentation/src/main/java/com/kkkk/presentation/main/rhythm/component/RhythmBottomSheet.kt
+++ b/presentation/src/main/java/com/kkkk/presentation/main/rhythm/component/RhythmBottomSheet.kt
@@ -140,7 +140,7 @@ fun RhythmBitSelectGrid(
             .padding(horizontal = 20.dp)
             .fillMaxWidth()
     ) {
-        items(listOf(2, 3, 4, 6, 8)) { bit ->
+        items(listOf(2, 3, 4, 6, 8), key = { it }) { bit ->
             RhythmBitItem(
                 bit = bit,
                 isSelected = bit == tempBit,
@@ -195,7 +195,7 @@ fun RhythmBpmSelectGrid(
             .fillMaxWidth(),
         horizontalArrangement = Arrangement.Center
     ) {
-        items(listOf(65, 75, 85, 95, 105, 115)) { bpm ->
+        items(listOf(65, 75, 85, 95, 105, 115), key = { it }) { bpm ->
             RhythmBpmItem(
                 bpm = bpm,
                 isSelected = tempBpm == bpm,

--- a/presentation/src/main/java/com/kkkk/presentation/main/rhythm/component/RhythmBottomSheet.kt
+++ b/presentation/src/main/java/com/kkkk/presentation/main/rhythm/component/RhythmBottomSheet.kt
@@ -20,6 +20,7 @@ import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
 import androidx.compose.material3.ModalBottomSheet
+import androidx.compose.material3.SheetState
 import androidx.compose.material3.Text
 import androidx.compose.material3.rememberModalBottomSheetState
 import androidx.compose.runtime.Composable
@@ -55,12 +56,11 @@ import com.kkkk.stempo.presentation.R
 @Composable
 fun RhythmBottomSheet(
     rhythmState: RhythmState,
+    sheetState: SheetState = rememberModalBottomSheetState(),
     modifier: Modifier = Modifier,
     onDismissRequest: () -> Unit = {},
     onSubmitBtnClick: (tempBit: Int, tempBpm: Int) -> Unit = { _, _ -> }
 ) {
-    val sheetState = rememberModalBottomSheetState()
-
     var tempBit by remember { mutableIntStateOf(rhythmState.bit) }
     var tempBpm by remember { mutableIntStateOf(rhythmState.bpm) }
 
@@ -263,12 +263,15 @@ fun RhythmBpmItem(
     }
 }
 
+@OptIn(ExperimentalMaterial3Api::class)
 @Preview(showBackground = true)
 @Composable
 fun RhythmBottomSheetPreview() {
     StempoTheme {
+        val sheetState: SheetState = rememberModalBottomSheetState()
         RhythmBottomSheet(
-            rhythmState = RhythmState()
+            rhythmState = RhythmState(),
+            sheetState = sheetState
         )
     }
 }

--- a/presentation/src/main/java/com/kkkk/presentation/main/rhythm/component/RhythmBottomSheet.kt
+++ b/presentation/src/main/java/com/kkkk/presentation/main/rhythm/component/RhythmBottomSheet.kt
@@ -11,6 +11,7 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.lazy.grid.GridCells
 import androidx.compose.foundation.lazy.grid.LazyVerticalGrid
 import androidx.compose.foundation.lazy.grid.items
@@ -30,6 +31,7 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.res.vectorResource
@@ -75,7 +77,7 @@ fun RhythmBottomSheet(
                 horizontalAlignment = Alignment.CenterHorizontally
             ) {
                 Spacer(
-                    modifier = Modifier.height(8.dp)
+                    modifier = Modifier.height(14.dp)
                 )
                 Icon(
                     imageVector = ImageVector.vectorResource(id = R.drawable.ic_drag_handle),
@@ -134,40 +136,22 @@ fun RhythmBottomSheet(
                 verticalAlignment = Alignment.CenterVertically,
                 horizontalArrangement = Arrangement.SpaceAround
             ) {
-                IconButton(
+                RhythmModIcon(
+                    iconResource = if (tempBpm > MIN_BPM) R.drawable.ic_minus_purple else R.drawable.ic_minus_gray,
+                    isEnabled = tempBpm > MIN_BPM,
                     onClick = { if (tempBpm > MIN_BPM) tempBpm -= 5 },
-                    enabled = tempBpm > MIN_BPM
-                ) {
-                    Icon(
-                        imageVector = ImageVector.vectorResource(
-                            id = if (tempBpm > MIN_BPM) {
-                                R.drawable.ic_minus_purple
-                            } else {
-                                R.drawable.ic_minus_gray
-                            }
-                        ),
-                        contentDescription = null
-                    )
-                }
+                    modifier = Modifier.padding(start = 20.dp)
+                )
                 Text(
                     text = "$tempBpm",
                     style = StempoTheme.typography.head1,
                 )
-                IconButton(
+                RhythmModIcon(
+                    iconResource = if (tempBpm < MAX_BPM) R.drawable.ic_plus_purple else R.drawable.ic_plus_gray,
+                    isEnabled = tempBpm < MAX_BPM,
                     onClick = { if (tempBpm < MAX_BPM) tempBpm += 5 },
-                    enabled = tempBpm < MAX_BPM
-                ) {
-                    Icon(
-                        imageVector = ImageVector.vectorResource(
-                            id = if (tempBpm < MAX_BPM) {
-                                R.drawable.ic_plus_purple
-                            } else {
-                                R.drawable.ic_plus_gray
-                            }
-                        ),
-                        contentDescription = null
-                    )
-                }
+                    modifier = Modifier.padding(end = 20.dp)
+                )
             }
 
             LazyVerticalGrid(
@@ -231,6 +215,25 @@ fun RhythmBitItem(
             color = if (isSelected) White else Gray600
         )
     }
+}
+
+@Composable
+fun RhythmModIcon(
+    iconResource: Int,
+    isEnabled: Boolean,
+    onClick: () -> Unit,
+    modifier: Modifier = Modifier
+) {
+    Icon(
+        imageVector = ImageVector.vectorResource(id = iconResource),
+        contentDescription = null,
+        tint = Color.Unspecified,
+        modifier = modifier
+            .size(54.dp)
+            .clickableWithoutRipple(enabled = isEnabled) {
+                if (isEnabled) onClick()
+            }
+    )
 }
 
 @Composable

--- a/presentation/src/main/java/com/kkkk/presentation/main/rhythm/component/RhythmBottomSheet.kt
+++ b/presentation/src/main/java/com/kkkk/presentation/main/rhythm/component/RhythmBottomSheet.kt
@@ -1,22 +1,24 @@
 package com.kkkk.presentation.main.rhythm.component
 
 import androidx.compose.foundation.background
+import androidx.compose.foundation.border
+import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
-import androidx.compose.foundation.layout.heightIn
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.grid.GridCells
 import androidx.compose.foundation.lazy.grid.LazyVerticalGrid
 import androidx.compose.foundation.lazy.grid.items
 import androidx.compose.foundation.shape.RoundedCornerShape
-import androidx.compose.material3.Divider
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
 import androidx.compose.material3.ModalBottomSheet
 import androidx.compose.material3.Text
 import androidx.compose.material3.rememberModalBottomSheetState
@@ -29,15 +31,20 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.vector.ImageVector
-import androidx.compose.ui.platform.LocalConfiguration
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.res.vectorResource
+import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import com.kkkk.presentation.main.rhythm.RhythmState
+import com.kkkk.presentation.main.rhythm.RhythmState.Companion.MAX_BPM
+import com.kkkk.presentation.main.rhythm.RhythmState.Companion.MIN_BPM
+import com.kkkk.presentation.main.theme.Gray100
 import com.kkkk.presentation.main.theme.Gray200
 import com.kkkk.presentation.main.theme.Gray300
 import com.kkkk.presentation.main.theme.Gray500
 import com.kkkk.presentation.main.theme.Gray600
+import com.kkkk.presentation.main.theme.Purple10
 import com.kkkk.presentation.main.theme.Purple50
 import com.kkkk.presentation.main.theme.StempoTheme
 import com.kkkk.presentation.main.theme.White
@@ -88,7 +95,7 @@ fun RhythmBottomSheet(
                 style = StempoTheme.typography.head4,
                 modifier = Modifier
                     .padding(top = 10.dp)
-                    .padding(horizontal = 20.dp)
+                    .padding(horizontal = 30.dp)
             )
 
             LazyVerticalGrid(
@@ -117,10 +124,88 @@ fun RhythmBottomSheet(
             Text(
                 text = "빠르기 선택",
                 style = StempoTheme.typography.head4,
-                modifier = Modifier.padding(horizontal = 20.dp)
+                modifier = Modifier.padding(horizontal = 30.dp)
             )
 
-            
+            Row(
+                modifier = Modifier
+                    .padding(top = 16.dp)
+                    .fillMaxWidth(),
+                verticalAlignment = Alignment.CenterVertically,
+                horizontalArrangement = Arrangement.SpaceAround
+            ) {
+                IconButton(
+                    onClick = { if (tempBpm > MIN_BPM) tempBpm -= 5 },
+                    enabled = tempBpm > MIN_BPM
+                ) {
+                    Icon(
+                        imageVector = ImageVector.vectorResource(
+                            id = if (tempBpm > MIN_BPM) {
+                                R.drawable.ic_minus_purple
+                            } else {
+                                R.drawable.ic_minus_gray
+                            }
+                        ),
+                        contentDescription = null
+                    )
+                }
+                Text(
+                    text = "$tempBpm",
+                    style = StempoTheme.typography.head1,
+                )
+                IconButton(
+                    onClick = { if (tempBpm < MAX_BPM) tempBpm += 5 },
+                    enabled = tempBpm < MAX_BPM
+                ) {
+                    Icon(
+                        imageVector = ImageVector.vectorResource(
+                            id = if (tempBpm < MAX_BPM) {
+                                R.drawable.ic_plus_purple
+                            } else {
+                                R.drawable.ic_plus_gray
+                            }
+                        ),
+                        contentDescription = null
+                    )
+                }
+            }
+
+            LazyVerticalGrid(
+                columns = GridCells.Fixed(3),
+                modifier = Modifier
+                    .padding(top = 24.dp)
+                    .padding(horizontal = 20.dp)
+                    .fillMaxWidth(),
+                horizontalArrangement = Arrangement.Center
+            ) {
+                items(listOf(65, 75, 85, 95, 105, 115)) { bpm ->
+                    RhythmBpmItem(
+                        bpm = bpm,
+                        isSelected = tempBpm == bpm,
+                        onBpmSelected = {tempBpm = bpm}
+                    )
+                }
+            }
+
+            Spacer(modifier = Modifier.weight(1f))
+
+            Text(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(horizontal = 20.dp)
+                    .padding(bottom = 16.dp)
+                    .align(Alignment.CenterHorizontally)
+                    .background(
+                        shape = RoundedCornerShape(12.dp),
+                        color = Purple10
+                    )
+                    .clickableWithoutRipple { onSubmitBtnClick(tempBit, tempBpm) }
+                    .padding(vertical = 15.dp),
+                text = stringResource(R.string.rhythm_btn_submit_level),
+                textAlign = TextAlign.Center,
+                color = Purple50,
+                style = StempoTheme.typography.head4
+            )
         }
     }
 }
@@ -144,6 +229,34 @@ fun RhythmBitItem(
             text = "$bit 박자",
             style = StempoTheme.typography.head2,
             color = if (isSelected) White else Gray600
+        )
+    }
+}
+
+@Composable
+fun RhythmBpmItem(
+    bpm: Int,
+    isSelected: Boolean,
+    onBpmSelected: (Int) -> Unit
+) {
+    Box(
+        modifier = Modifier
+            .padding(8.dp)
+            .clip(RoundedCornerShape(25.dp))
+            .background(if (isSelected) White else Gray100)
+            .border(
+                width = 2.dp,
+                color = if (isSelected) Purple50 else Gray300,
+                shape = RoundedCornerShape(25.dp)
+            )
+            .clickableWithoutRipple { onBpmSelected(bpm) }
+            .padding(vertical = 12.dp),
+        contentAlignment = Alignment.Center
+    ) {
+        Text(
+            text = bpm.toString(),
+            color = if (isSelected) Purple50 else Gray500,
+            style = StempoTheme.typography.head3
         )
     }
 }

--- a/presentation/src/main/java/com/kkkk/presentation/main/rhythm/component/RhythmBottomSheet.kt
+++ b/presentation/src/main/java/com/kkkk/presentation/main/rhythm/component/RhythmBottomSheet.kt
@@ -19,7 +19,6 @@ import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
-import androidx.compose.material3.IconButton
 import androidx.compose.material3.ModalBottomSheet
 import androidx.compose.material3.Text
 import androidx.compose.material3.rememberModalBottomSheetState
@@ -166,7 +165,7 @@ fun RhythmBottomSheet(
                     RhythmBpmItem(
                         bpm = bpm,
                         isSelected = tempBpm == bpm,
-                        onBpmSelected = {tempBpm = bpm}
+                        onBpmSelected = { tempBpm = bpm }
                     )
                 }
             }

--- a/presentation/src/main/java/com/kkkk/presentation/main/rhythm/component/RhythmBottomSheet.kt
+++ b/presentation/src/main/java/com/kkkk/presentation/main/rhythm/component/RhythmBottomSheet.kt
@@ -1,17 +1,15 @@
 package com.kkkk.presentation.main.rhythm.component
 
 import androidx.compose.foundation.background
-import androidx.compose.foundation.border
 import androidx.compose.foundation.layout.Arrangement
-import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.ColumnScope
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.lazy.grid.GridCells
 import androidx.compose.foundation.lazy.grid.LazyVerticalGrid
 import androidx.compose.foundation.lazy.grid.items
@@ -30,8 +28,6 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.draw.clip
-import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.res.vectorResource
@@ -41,11 +37,8 @@ import androidx.compose.ui.unit.dp
 import com.kkkk.presentation.main.rhythm.RhythmState
 import com.kkkk.presentation.main.rhythm.RhythmState.Companion.MAX_BPM
 import com.kkkk.presentation.main.rhythm.RhythmState.Companion.MIN_BPM
-import com.kkkk.presentation.main.theme.Gray100
-import com.kkkk.presentation.main.theme.Gray200
 import com.kkkk.presentation.main.theme.Gray300
 import com.kkkk.presentation.main.theme.Gray500
-import com.kkkk.presentation.main.theme.Gray600
 import com.kkkk.presentation.main.theme.Purple10
 import com.kkkk.presentation.main.theme.Purple50
 import com.kkkk.presentation.main.theme.StempoTheme
@@ -75,9 +68,7 @@ fun RhythmBottomSheet(
                 modifier = Modifier.fillMaxWidth(),
                 horizontalAlignment = Alignment.CenterHorizontally
             ) {
-                Spacer(
-                    modifier = Modifier.height(14.dp)
-                )
+                Spacer(modifier = Modifier.height(14.dp))
                 Icon(
                     imageVector = ImageVector.vectorResource(id = R.drawable.ic_drag_handle),
                     contentDescription = null,
@@ -89,31 +80,20 @@ fun RhythmBottomSheet(
         sheetState = sheetState
     ) {
         Column(
-            modifier = Modifier.fillMaxWidth(),
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(top = 10.dp),
         ) {
             Text(
                 text = "박자 선택",
                 style = StempoTheme.typography.head4,
-                modifier = Modifier
-                    .padding(top = 10.dp)
-                    .padding(horizontal = 30.dp)
+                modifier = Modifier.padding(horizontal = 30.dp)
             )
 
-            LazyVerticalGrid(
-                columns = GridCells.Fixed(2),
-                modifier = Modifier
-                    .padding(top = 10.dp)
-                    .padding(horizontal = 20.dp)
-                    .fillMaxWidth()
-            ) {
-                items(listOf(2, 3, 4, 6, 8)) { bit ->
-                    RhythmBitItem(
-                        bit = bit,
-                        isSelected = bit == tempBit,
-                        onBitClick = { tempBit = bit }
-                    )
-                }
-            }
+            RhythmBitSelectGrid(
+                tempBit = tempBit,
+                onBitClick = { tempBit = it }
+            )
 
             HorizontalDivider(
                 modifier = Modifier
@@ -128,139 +108,124 @@ fun RhythmBottomSheet(
                 modifier = Modifier.padding(horizontal = 30.dp)
             )
 
-            Row(
-                modifier = Modifier
-                    .padding(top = 16.dp)
-                    .fillMaxWidth(),
-                verticalAlignment = Alignment.CenterVertically,
-                horizontalArrangement = Arrangement.SpaceAround
-            ) {
-                RhythmModIcon(
-                    iconResource = if (tempBpm > MIN_BPM) R.drawable.ic_minus_purple else R.drawable.ic_minus_gray,
-                    isEnabled = tempBpm > MIN_BPM,
-                    onClick = { if (tempBpm > MIN_BPM) tempBpm -= 5 },
-                    modifier = Modifier.padding(start = 20.dp)
-                )
-                Text(
-                    text = "$tempBpm",
-                    style = StempoTheme.typography.head1,
-                )
-                RhythmModIcon(
-                    iconResource = if (tempBpm < MAX_BPM) R.drawable.ic_plus_purple else R.drawable.ic_plus_gray,
-                    isEnabled = tempBpm < MAX_BPM,
-                    onClick = { if (tempBpm < MAX_BPM) tempBpm += 5 },
-                    modifier = Modifier.padding(end = 20.dp)
-                )
-            }
+            RhythmBpmUpDownBtns(
+                tempBpm = tempBpm,
+                onMinusBtnClick = { if (tempBpm > MIN_BPM) tempBpm -= 5 },
+                onPlusBtnClick = { if (tempBpm < MAX_BPM) tempBpm += 5 }
+            )
 
-            LazyVerticalGrid(
-                columns = GridCells.Fixed(3),
-                modifier = Modifier
-                    .padding(top = 24.dp)
-                    .padding(horizontal = 20.dp)
-                    .fillMaxWidth(),
-                horizontalArrangement = Arrangement.Center
-            ) {
-                items(listOf(65, 75, 85, 95, 105, 115)) { bpm ->
-                    RhythmBpmItem(
-                        bpm = bpm,
-                        isSelected = tempBpm == bpm,
-                        onBpmSelected = { tempBpm = bpm }
-                    )
-                }
-            }
+            RhythmBpmSelectGrid(
+                tempBpm = tempBpm,
+                onBpmSelected = { tempBpm = it }
+            )
 
             Spacer(modifier = Modifier.weight(1f))
 
-            Text(
-                modifier = Modifier
-                    .fillMaxWidth()
-                    .padding(horizontal = 20.dp)
-                    .padding(bottom = 16.dp)
-                    .align(Alignment.CenterHorizontally)
-                    .background(
-                        shape = RoundedCornerShape(12.dp),
-                        color = Purple10
-                    )
-                    .clickableWithoutRipple { onSubmitBtnClick(tempBit, tempBpm) }
-                    .padding(vertical = 15.dp),
-                text = stringResource(R.string.rhythm_btn_submit_level),
-                textAlign = TextAlign.Center,
-                color = Purple50,
-                style = StempoTheme.typography.head4
+            RhythmSubmitBtn(
+                onSubmitBtnClick = { onSubmitBtnClick(tempBit, tempBpm) }
             )
         }
     }
 }
 
 @Composable
-fun RhythmBitItem(
-    bit: Int,
-    isSelected: Boolean,
-    onBitClick: () -> Unit = {}
+fun RhythmBitSelectGrid(
+    tempBit: Int,
+    onBitClick: (bit: Int) -> Unit
 ) {
-    Box(
+    LazyVerticalGrid(
+        columns = GridCells.Fixed(2),
         modifier = Modifier
-            .padding(8.dp)
-            .clip(RoundedCornerShape(17.dp))
-            .background(if (isSelected) Purple50 else Gray200)
-            .clickableWithoutRipple { onBitClick() }
-            .padding(vertical = 12.dp),
-        contentAlignment = Alignment.Center
+            .padding(top = 10.dp)
+            .padding(horizontal = 20.dp)
+            .fillMaxWidth()
     ) {
-        Text(
-            text = "$bit 박자",
-            style = StempoTheme.typography.head2,
-            color = if (isSelected) White else Gray600
-        )
-    }
-}
-
-@Composable
-fun RhythmModIcon(
-    iconResource: Int,
-    isEnabled: Boolean,
-    onClick: () -> Unit,
-    modifier: Modifier = Modifier
-) {
-    Icon(
-        imageVector = ImageVector.vectorResource(id = iconResource),
-        contentDescription = null,
-        tint = Color.Unspecified,
-        modifier = modifier
-            .size(54.dp)
-            .clickableWithoutRipple(enabled = isEnabled) {
-                if (isEnabled) onClick()
-            }
-    )
-}
-
-@Composable
-fun RhythmBpmItem(
-    bpm: Int,
-    isSelected: Boolean,
-    onBpmSelected: (Int) -> Unit
-) {
-    Box(
-        modifier = Modifier
-            .padding(8.dp)
-            .clip(RoundedCornerShape(25.dp))
-            .background(if (isSelected) White else Gray100)
-            .border(
-                width = 2.dp,
-                color = if (isSelected) Purple50 else Gray300,
-                shape = RoundedCornerShape(25.dp)
+        items(listOf(2, 3, 4, 6, 8)) { bit ->
+            RhythmBitItem(
+                bit = bit,
+                isSelected = bit == tempBit,
+                onBitClick = { onBitClick(bit) }
             )
-            .clickableWithoutRipple { onBpmSelected(bpm) }
-            .padding(vertical = 12.dp),
-        contentAlignment = Alignment.Center
+        }
+    }
+}
+
+@Composable
+fun RhythmBpmUpDownBtns(
+    tempBpm: Int,
+    onMinusBtnClick: () -> Unit,
+    onPlusBtnClick: () -> Unit,
+) {
+    Row(
+        modifier = Modifier
+            .padding(top = 16.dp)
+            .fillMaxWidth(),
+        verticalAlignment = Alignment.CenterVertically,
+        horizontalArrangement = Arrangement.SpaceAround
     ) {
+        RhythmUpDownBtn(
+            iconResource = if (tempBpm > MIN_BPM) R.drawable.ic_minus_purple else R.drawable.ic_minus_gray,
+            isEnabled = tempBpm > MIN_BPM,
+            onClick = { if (tempBpm > MIN_BPM) onMinusBtnClick() },
+            modifier = Modifier.padding(start = 20.dp)
+        )
         Text(
-            text = bpm.toString(),
-            color = if (isSelected) Purple50 else Gray500,
-            style = StempoTheme.typography.head3
+            text = "$tempBpm",
+            style = StempoTheme.typography.head1,
+        )
+        RhythmUpDownBtn(
+            iconResource = if (tempBpm < MAX_BPM) R.drawable.ic_plus_purple else R.drawable.ic_plus_gray,
+            isEnabled = tempBpm < MAX_BPM,
+            onClick = { if (tempBpm < MAX_BPM) onPlusBtnClick() },
+            modifier = Modifier.padding(end = 20.dp)
         )
     }
+}
+
+@Composable
+fun RhythmBpmSelectGrid(
+    tempBpm: Int,
+    onBpmSelected: (bpm: Int) -> Unit
+) {
+    LazyVerticalGrid(
+        columns = GridCells.Fixed(3),
+        modifier = Modifier
+            .padding(top = 24.dp)
+            .padding(horizontal = 20.dp)
+            .fillMaxWidth(),
+        horizontalArrangement = Arrangement.Center
+    ) {
+        items(listOf(65, 75, 85, 95, 105, 115)) { bpm ->
+            RhythmBpmItem(
+                bpm = bpm,
+                isSelected = tempBpm == bpm,
+                onBpmSelected = { onBpmSelected(bpm) }
+            )
+        }
+    }
+}
+
+@Composable
+fun ColumnScope.RhythmSubmitBtn(
+    onSubmitBtnClick: () -> Unit
+) {
+    Text(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(horizontal = 20.dp)
+            .padding(bottom = 16.dp)
+            .align(Alignment.CenterHorizontally)
+            .background(
+                shape = RoundedCornerShape(12.dp),
+                color = Purple10
+            )
+            .clickableWithoutRipple { onSubmitBtnClick() }
+            .padding(vertical = 15.dp),
+        text = stringResource(R.string.rhythm_btn_submit_level),
+        textAlign = TextAlign.Center,
+        color = Purple50,
+        style = StempoTheme.typography.head4
+    )
 }
 
 @OptIn(ExperimentalMaterial3Api::class)

--- a/presentation/src/main/java/com/kkkk/presentation/main/rhythm/component/RhythmBottomSheet.kt
+++ b/presentation/src/main/java/com/kkkk/presentation/main/rhythm/component/RhythmBottomSheet.kt
@@ -1,0 +1,159 @@
+package com.kkkk.presentation.main.rhythm.component
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.heightIn
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.lazy.grid.GridCells
+import androidx.compose.foundation.lazy.grid.LazyVerticalGrid
+import androidx.compose.foundation.lazy.grid.items
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.Divider
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.HorizontalDivider
+import androidx.compose.material3.Icon
+import androidx.compose.material3.ModalBottomSheet
+import androidx.compose.material3.Text
+import androidx.compose.material3.rememberModalBottomSheetState
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableIntStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.platform.LocalConfiguration
+import androidx.compose.ui.res.vectorResource
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import com.kkkk.presentation.main.rhythm.RhythmState
+import com.kkkk.presentation.main.theme.Gray200
+import com.kkkk.presentation.main.theme.Gray300
+import com.kkkk.presentation.main.theme.Gray500
+import com.kkkk.presentation.main.theme.Gray600
+import com.kkkk.presentation.main.theme.Purple50
+import com.kkkk.presentation.main.theme.StempoTheme
+import com.kkkk.presentation.main.theme.White
+import com.kkkk.stempo.presentation.R
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun RhythmBottomSheet(
+    rhythmState: RhythmState,
+    modifier: Modifier = Modifier,
+    onDismissRequest: () -> Unit = {},
+    onSubmitBtnClick: (tempBit: Int, tempBpm: Int) -> Unit = { _, _ -> }
+) {
+    val sheetState = rememberModalBottomSheetState()
+
+    var tempBit by remember { mutableIntStateOf(rhythmState.bit) }
+    var tempBpm by remember { mutableIntStateOf(rhythmState.bpm) }
+
+    ModalBottomSheet(
+        modifier = modifier.fillMaxSize(),
+        containerColor = White,
+        onDismissRequest = {
+            onDismissRequest()
+        },
+        dragHandle = {
+            Column(
+                modifier = Modifier.fillMaxWidth(),
+                horizontalAlignment = Alignment.CenterHorizontally
+            ) {
+                Spacer(
+                    modifier = Modifier.height(8.dp)
+                )
+                Icon(
+                    imageVector = ImageVector.vectorResource(id = R.drawable.ic_drag_handle),
+                    contentDescription = null,
+                    tint = Gray500,
+                )
+                Spacer(modifier = Modifier.height(14.dp))
+            }
+        },
+        sheetState = sheetState
+    ) {
+        Column(
+            modifier = Modifier.fillMaxWidth(),
+        ) {
+            Text(
+                text = "박자 선택",
+                style = StempoTheme.typography.head4,
+                modifier = Modifier
+                    .padding(top = 10.dp)
+                    .padding(horizontal = 20.dp)
+            )
+
+            LazyVerticalGrid(
+                columns = GridCells.Fixed(2),
+                modifier = Modifier
+                    .padding(top = 10.dp)
+                    .padding(horizontal = 20.dp)
+                    .fillMaxWidth()
+            ) {
+                items(listOf(2, 3, 4, 6, 8)) { bit ->
+                    RhythmBitItem(
+                        bit = bit,
+                        isSelected = bit == tempBit,
+                        onBitClick = { tempBit = bit }
+                    )
+                }
+            }
+
+            HorizontalDivider(
+                modifier = Modifier
+                    .padding(horizontal = 20.dp, vertical = 20.dp)
+                    .height(2.dp),
+                color = Gray300
+            )
+
+            Text(
+                text = "빠르기 선택",
+                style = StempoTheme.typography.head4,
+                modifier = Modifier.padding(horizontal = 20.dp)
+            )
+
+            
+        }
+    }
+}
+
+@Composable
+fun RhythmBitItem(
+    bit: Int,
+    isSelected: Boolean,
+    onBitClick: () -> Unit = {}
+) {
+    Box(
+        modifier = Modifier
+            .padding(8.dp)
+            .clip(RoundedCornerShape(17.dp))
+            .background(if (isSelected) Purple50 else Gray200)
+            .clickableWithoutRipple { onBitClick() }
+            .padding(vertical = 12.dp),
+        contentAlignment = Alignment.Center
+    ) {
+        Text(
+            text = "$bit 박자",
+            style = StempoTheme.typography.head2,
+            color = if (isSelected) White else Gray600
+        )
+    }
+}
+
+@Preview(showBackground = true)
+@Composable
+fun RhythmBottomSheetPreview() {
+    StempoTheme {
+        RhythmBottomSheet(
+            rhythmState = RhythmState()
+        )
+    }
+}

--- a/presentation/src/main/java/com/kkkk/presentation/main/rhythm/component/RhythmBpmItem.kt
+++ b/presentation/src/main/java/com/kkkk/presentation/main/rhythm/component/RhythmBpmItem.kt
@@ -1,0 +1,47 @@
+package com.kkkk.presentation.main.rhythm.component
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.border
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.unit.dp
+import com.kkkk.presentation.main.theme.Gray100
+import com.kkkk.presentation.main.theme.Gray300
+import com.kkkk.presentation.main.theme.Gray500
+import com.kkkk.presentation.main.theme.Purple50
+import com.kkkk.presentation.main.theme.StempoTheme
+import com.kkkk.presentation.main.theme.White
+
+@Composable
+fun RhythmBpmItem(
+    bpm: Int,
+    isSelected: Boolean,
+    onBpmSelected: (Int) -> Unit
+) {
+    Box(
+        modifier = Modifier
+            .padding(8.dp)
+            .clip(RoundedCornerShape(25.dp))
+            .background(if (isSelected) White else Gray100)
+            .border(
+                width = 2.dp,
+                color = if (isSelected) Purple50 else Gray300,
+                shape = RoundedCornerShape(25.dp)
+            )
+            .clickableWithoutRipple { onBpmSelected(bpm) }
+            .padding(vertical = 12.dp),
+        contentAlignment = Alignment.Center
+    ) {
+        Text(
+            text = bpm.toString(),
+            color = if (isSelected) Purple50 else Gray500,
+            style = StempoTheme.typography.head3
+        )
+    }
+}

--- a/presentation/src/main/java/com/kkkk/presentation/main/rhythm/component/RhythmChip.kt
+++ b/presentation/src/main/java/com/kkkk/presentation/main/rhythm/component/RhythmChip.kt
@@ -1,0 +1,58 @@
+package com.kkkk.presentation.main.rhythm.component
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.border
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import com.kkkk.presentation.main.theme.Gray600
+import com.kkkk.presentation.main.theme.Purple50
+import com.kkkk.presentation.main.theme.StempoTheme
+import com.kkkk.presentation.main.theme.White
+
+@Composable
+fun RhythmChip(
+    text: String,
+    modifier: Modifier = Modifier,
+    color: Color = Gray600,
+    isFilled: Boolean = false,
+) {
+    Box(
+        modifier = modifier
+            .background(
+                color = if (isFilled) color else White,
+                shape = RoundedCornerShape(20.dp)
+            )
+            .border(
+                width = 2.dp,
+                color = color,
+                shape = RoundedCornerShape(20.dp)
+            )
+            .padding(horizontal = 16.dp, vertical = 6.dp),
+        contentAlignment = Alignment.Center
+    ) {
+        Text(
+            text = text,
+            color = if (isFilled) White else color,
+            style = StempoTheme.typography.body2
+        )
+    }
+}
+
+@Preview(showBackground = true)
+@Composable
+fun RhythmChipPreview() {
+    StempoTheme {
+        RhythmChip(
+            text = "2비트",
+            color = Purple50
+        )
+    }
+}

--- a/presentation/src/main/java/com/kkkk/presentation/main/rhythm/component/RhythmModeToggle.kt
+++ b/presentation/src/main/java/com/kkkk/presentation/main/rhythm/component/RhythmModeToggle.kt
@@ -1,0 +1,91 @@
+package com.kkkk.presentation.main.rhythm.component
+
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import com.kkkk.presentation.main.rhythm.RhythmMode
+import com.kkkk.presentation.main.theme.Black
+import com.kkkk.presentation.main.theme.Gray200
+import com.kkkk.presentation.main.theme.Gray600
+import com.kkkk.presentation.main.theme.StempoTheme
+import com.kkkk.presentation.main.theme.Transparent
+import com.kkkk.presentation.main.theme.White
+
+
+@Composable
+fun RhythmModeToggle(
+    modifier: Modifier = Modifier,
+    selectedMode: RhythmMode = RhythmMode.RHYTHM,
+    onToggleSelected: (RhythmMode) -> Unit
+) {
+    Row(
+        modifier = modifier
+            .background(color = Gray200, shape = RoundedCornerShape(26.dp))
+            .padding(4.dp)
+            .clip(RoundedCornerShape(26.dp))
+    ) {
+        RhythmModeToggleItem(
+            mode = RhythmMode.RHYTHM,
+            selectedMode = selectedMode,
+            onToggleClick = onToggleSelected,
+            modifier = Modifier.weight(1f)
+        )
+        RhythmModeToggleItem(
+            mode = RhythmMode.STRETCH,
+            selectedMode = selectedMode,
+            onToggleClick = onToggleSelected,
+            modifier = Modifier.weight(1f)
+        )
+    }
+}
+
+@Composable
+fun RhythmModeToggleItem(
+    mode: RhythmMode,
+    selectedMode: RhythmMode,
+    onToggleClick: (RhythmMode) -> Unit,
+    modifier: Modifier = Modifier
+) {
+    Box(
+        modifier = modifier
+            .clip(RoundedCornerShape(26.dp))
+            .background(if (selectedMode == mode) White else Transparent)
+            .clickable { onToggleClick(mode) }
+            .padding(vertical = 8.dp),
+        contentAlignment = Alignment.Center
+    ) {
+        Text(
+            text = mode.text,
+            color = if (selectedMode == mode) Black else Gray600,
+            style = StempoTheme.typography.head3,
+        )
+    }
+}
+
+@Preview(showBackground = true)
+@Composable
+fun RhythmModeTogglePreview() {
+    var selectedMode by remember { mutableStateOf(RhythmMode.RHYTHM) }
+
+    StempoTheme {
+        RhythmModeToggle(
+            selectedMode = selectedMode,
+            onToggleSelected = { selectedMode = it }
+        )
+    }
+}

--- a/presentation/src/main/java/com/kkkk/presentation/main/rhythm/component/RhythmModeToggle.kt
+++ b/presentation/src/main/java/com/kkkk/presentation/main/rhythm/component/RhythmModeToggle.kt
@@ -2,7 +2,6 @@ package com.kkkk.presentation.main.rhythm.component
 
 
 import androidx.compose.foundation.background
-import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.padding
@@ -65,7 +64,7 @@ fun RhythmModeToggleItem(
         modifier = modifier
             .clip(RoundedCornerShape(26.dp))
             .background(if (selectedMode == mode) White else Transparent)
-            .clickable { onToggleClick(mode) }
+            .clickableWithoutRipple { onToggleClick(mode) }
             .padding(vertical = 8.dp),
         contentAlignment = Alignment.Center
     ) {

--- a/presentation/src/main/java/com/kkkk/presentation/main/rhythm/component/RhythmUpDownBtn.kt
+++ b/presentation/src/main/java/com/kkkk/presentation/main/rhythm/component/RhythmUpDownBtn.kt
@@ -1,0 +1,27 @@
+package com.kkkk.presentation.main.rhythm.component
+
+import androidx.compose.foundation.layout.size
+import androidx.compose.material3.Icon
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.res.vectorResource
+import androidx.compose.ui.unit.dp
+
+@Composable
+fun RhythmUpDownBtn(
+    iconResource: Int,
+    isEnabled: Boolean,
+    onClick: () -> Unit,
+    modifier: Modifier = Modifier
+) {
+    Icon(
+        imageVector = ImageVector.vectorResource(id = iconResource),
+        contentDescription = null,
+        tint = Color.Unspecified,
+        modifier = modifier
+            .size(54.dp)
+            .clickableWithoutRipple(enabled = isEnabled) { if (isEnabled) onClick() }
+    )
+}

--- a/presentation/src/main/java/com/kkkk/presentation/main/theme/Theme.kt
+++ b/presentation/src/main/java/com/kkkk/presentation/main/theme/Theme.kt
@@ -6,8 +6,11 @@ import androidx.compose.material3.darkColorScheme
 import androidx.compose.material3.lightColorScheme
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.runtime.SideEffect
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.staticCompositionLocalOf
+import androidx.compose.ui.graphics.Color
+import com.google.accompanist.systemuicontroller.rememberSystemUiController
 
 private val DarkColorScheme = darkColorScheme(
     primary = Purple80,
@@ -66,12 +69,39 @@ fun StempoTheme(
     // darkTheme을 지원하지 않기에 현재는 LightColorScheme만 사용합니다.
     val colorScheme = LightColorScheme
 
+    SetSystemBarsColor(
+        statusBarColor = Color.White,
+        navigationBarColor = Color.White,
+        darkIcons = true
+    )
+
     val typography = stempoTypography()
 
     ProvideStempoTypography(typography) {
         MaterialTheme(
             colorScheme = colorScheme,
             content = content
+        )
+    }
+}
+
+@Composable
+fun SetSystemBarsColor(
+    statusBarColor: Color = Color.White,
+    navigationBarColor: Color = Color.White,
+    darkIcons: Boolean = true
+) {
+    val systemUiController = rememberSystemUiController()
+
+    SideEffect {
+        systemUiController.setStatusBarColor(
+            color = statusBarColor,
+            darkIcons = darkIcons
+        )
+
+        systemUiController.setNavigationBarColor(
+            color = navigationBarColor,
+            darkIcons = darkIcons
         )
     }
 }

--- a/presentation/src/main/java/com/kkkk/presentation/main/theme/Typography.kt
+++ b/presentation/src/main/java/com/kkkk/presentation/main/theme/Typography.kt
@@ -19,22 +19,22 @@ val PretendardMedium = FontFamily(Font(R.font.pretendard_medium, FontWeight.Medi
 
 @Stable
 class StempoTypography internal constructor(
-    head0: TextStyle,
     head1: TextStyle,
     head2: TextStyle,
     head3: TextStyle,
+    head4: TextStyle,
     body1: TextStyle,
     body2: TextStyle,
     body3: TextStyle,
     caption1: TextStyle,
 ) {
-    var head0: TextStyle by mutableStateOf(head0)
-        private set
     var head1: TextStyle by mutableStateOf(head1)
         private set
     var head2: TextStyle by mutableStateOf(head2)
         private set
     var head3: TextStyle by mutableStateOf(head3)
+        private set
+    var head4: TextStyle by mutableStateOf(head4)
         private set
     var body1: TextStyle by mutableStateOf(body1)
         private set
@@ -46,10 +46,10 @@ class StempoTypography internal constructor(
         private set
 
     fun copy(
-        head0: TextStyle = this.head0,
-        head1: TextStyle = this.head1,
-        head2: TextStyle = this.head2,
-        head3: TextStyle = this.head3,
+        head0: TextStyle = this.head1,
+        head1: TextStyle = this.head2,
+        head2: TextStyle = this.head3,
+        head3: TextStyle = this.head4,
         body1: TextStyle = this.body1,
         body2: TextStyle = this.body2,
         body3: TextStyle = this.body3,
@@ -66,10 +66,10 @@ class StempoTypography internal constructor(
     )
 
     fun update(other: StempoTypography) {
-        head0 = other.head0
         head1 = other.head1
         head2 = other.head2
         head3 = other.head3
+        head4 = other.head4
         body1 = other.body1
         body2 = other.body2
         body3 = other.body3
@@ -96,22 +96,22 @@ fun stempoTextStyle(
 @Composable
 fun stempoTypography(): StempoTypography {
     return StempoTypography(
-        head0 = stempoTextStyle(
+        head1 = stempoTextStyle(
             fontFamily = PretendardSemiBold,
             fontSize = 26.sp,
             lineHeight = 44.sp
         ),
-        head1 = stempoTextStyle(
+        head2 = stempoTextStyle(
             fontFamily = PretendardSemiBold,
             fontSize = 24.sp,
             lineHeight = 38.sp
         ),
-        head2 = stempoTextStyle(
+        head3 = stempoTextStyle(
             fontFamily = PretendardSemiBold,
             fontSize = 20.sp,
             lineHeight = 28.sp
         ),
-        head3 = stempoTextStyle(
+        head4 = stempoTextStyle(
             fontFamily = PretendardSemiBold,
             fontSize = 18.sp,
             lineHeight = 26.sp,

--- a/presentation/src/main/res/drawable/ic_drag_handle.xml
+++ b/presentation/src/main/res/drawable/ic_drag_handle.xml
@@ -1,0 +1,9 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="44dp"
+    android:height="4dp"
+    android:viewportWidth="44"
+    android:viewportHeight="4">
+    <path
+        android:fillColor="#E5E5E5"
+        android:pathData="M2,0L42,0A2,2 0,0 1,44 2L44,2A2,2 0,0 1,42 4L2,4A2,2 0,0 1,0 2L0,2A2,2 0,0 1,2 0z" />
+</vector>

--- a/presentation/src/main/res/layout/bottom_sheet_rhythm.xml
+++ b/presentation/src/main/res/layout/bottom_sheet_rhythm.xml
@@ -55,6 +55,7 @@
 
             <TextView
                 style="@style/TextAppearance.Stempo.Head2"
+                android:layout_height="wrap_content"
                 android:layout_row="0"
                 android:layout_rowWeight="1"
                 android:layout_column="0"

--- a/presentation/src/main/res/values/strings.xml
+++ b/presentation/src/main/res/values/strings.xml
@@ -35,6 +35,8 @@
     <string name="rhythm_stop_btn_save">종료하기</string>
     <string name="rhythm_stop_btn_pause">정지하기</string>
 
+    <string name="stretch_tv_title">리듬에 맞춰\n스트레칭을 진행해주세요!</string>
+
     <string name="report_tv_accuracy_average">정확도 평균 %d%%</string>
     <string name="report_tv_title">동안의 성과에요!</string>
     <string name="report_tv_achieve_title">달성한 업적</string>


### PR DESCRIPTION
- closed #91

## *⛳️ Work Description*
- 기존 리듬뷰 XML뷰에서 UI부분 다이얼로그 제외, 구현 완료
- 기존에 두개의 fragment로 구성되었던 리듬모드랑 스트레칭 통합
- 색상 부분 state로 이관
- 기능 migration은 다음 PR로 끊어서 진행

## *📸 Screenshot*
<!-- 실행 사진이나 영상을 드래그하여 첨부해주세요. -->
<!-- <img src="이미지 주소" width=270 /> -->

https://github.com/user-attachments/assets/5a79b05f-65d5-458d-b58c-23814ee2d02f


## *📢 To Reviewers*
- 후하 컴포즈 적응 반쯤 완료
- 컨벤션이나 패키징, 코드 스타일까지 세세하게 봐주시면 좋겟슴다 아무래도 아직 xml이 남아있는듯