### PR TITLE
[FIX/#95] 리듬뷰 / 기능 부분 로직 개선

### DIFF
--- a/domain/src/main/kotlin/com/kkkk/domain/entity/request/RecordRequestModel.kt
+++ b/domain/src/main/kotlin/com/kkkk/domain/entity/request/RecordRequestModel.kt
@@ -2,6 +2,6 @@ package com.kkkk.domain.entity.request
 
 data class RecordRequestModel(
     val accuracy: Double,
-    val duration: Int,
+    val duration: Int = 0,
     val steps: Int,
 )

--- a/presentation/src/main/java/com/kkkk/presentation/main/rhythm/RhythmScreen.kt
+++ b/presentation/src/main/java/com/kkkk/presentation/main/rhythm/RhythmScreen.kt
@@ -29,7 +29,6 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
-import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -59,8 +58,6 @@ import com.google.android.gms.wearable.Wearable
 import com.kkkk.core.extension.stringOf
 import com.kkkk.core.extension.toast
 import com.kkkk.presentation.main.rhythm.RhythmState.Companion.STRETCH_MUSIC_FILE
-import com.kkkk.presentation.main.rhythm.RhythmState.Companion.findMusicByBpm
-import com.kkkk.presentation.main.rhythm.RhythmViewModel.Companion.FLOAT_80
 import com.kkkk.presentation.main.rhythm.RhythmViewModel.Companion.KEY_RECORD
 import com.kkkk.presentation.main.rhythm.RhythmViewModel.Companion.PATH_END
 import com.kkkk.presentation.main.rhythm.RhythmViewModel.Companion.PATH_RECORD
@@ -100,9 +97,6 @@ fun RhythmRoute(
     val lottieLoading by rememberLottieComposition(
         LottieCompositionSpec.RawRes(R.raw.stempo_loading)
     )
-    val animationSpeed = remember(rhythmState.selectedMode, rhythmState.bpm) {
-        if (rhythmState.selectedMode == RhythmMode.RHYTHM) rhythmState.bpm / FLOAT_80 else 0.75F
-    }
 
     // 바텀시트 관련 상태
     val sheetState = rememberModalBottomSheetState(skipPartiallyExpanded = true)
@@ -137,7 +131,7 @@ fun RhythmRoute(
             if (rhythmState.selectedMode == RhythmMode.RHYTHM) {
                 viewModel.setMusicPlayer(
                     soundPoolFile = File(context.filesDir, rhythmState.filename),
-                    mediaPlayerAfd = context.resources.openRawResourceFd(findMusicByBpm(rhythmState.bpm))
+                    mediaPlayerAfd = context.resources.openRawResourceFd(rhythmState.musicByBpm)
                 )
             } else {
                 viewModel.setMusicPlayer(
@@ -196,7 +190,6 @@ fun RhythmRoute(
         rhythmState = rhythmState,
         lottiePlaying = lottiePlaying,
         lottieLoading = lottieLoading,
-        animationSpeed = animationSpeed,
         onToggleSelected = viewModel::changeSelectedMode,
         onWatchBtnClick = { viewModel.showSyncDialog(true) },
         onPlayBtnClick = { viewModel.changeIsPlaying(PlayState.PLAYING) },
@@ -241,7 +234,6 @@ internal fun RhythmScreen(
     rhythmState: RhythmState,
     lottiePlaying: LottieComposition?,
     lottieLoading: LottieComposition?,
-    animationSpeed: Float = 1f,
     onToggleSelected: (RhythmMode) -> Unit = {},
     onWatchBtnClick: () -> Unit = {},
     onPlayBtnClick: () -> Unit = {},
@@ -255,7 +247,6 @@ internal fun RhythmScreen(
         RhythmPlayBtnWithLottie(
             rhythmState = rhythmState,
             lottieComposition = lottiePlaying,
-            animationSpeed = animationSpeed,
             onPlayBtnClick = onPlayBtnClick,
             onStopBtnClick = onPauseBtnClick
         )
@@ -314,7 +305,6 @@ internal fun RhythmScreen(
 fun RhythmPlayBtnWithLottie(
     rhythmState: RhythmState,
     lottieComposition: LottieComposition?,
-    animationSpeed: Float = 1f,
     onPlayBtnClick: () -> Unit = {},
     onStopBtnClick: () -> Unit = {}
 ) {
@@ -341,7 +331,7 @@ fun RhythmPlayBtnWithLottie(
         LottieAnimation(
             composition = lottieComposition,
             iterations = LottieConstants.IterateForever,
-            speed = animationSpeed,
+            speed = rhythmState.animationSpeed,
             modifier = Modifier
                 .fillMaxWidth()
                 .aspectRatio(1f)

--- a/presentation/src/main/java/com/kkkk/presentation/main/rhythm/RhythmScreen.kt
+++ b/presentation/src/main/java/com/kkkk/presentation/main/rhythm/RhythmScreen.kt
@@ -87,7 +87,7 @@ fun RhythmRoute(
 
     // 시스템 서비스 및 데이터 클라이언트
     val sensorManager = context.getSystemService(Context.SENSOR_SERVICE) as SensorManager
-    val stepDetectorSensor = sensorManager.getDefaultSensor(Sensor.TYPE_STEP_DETECTOR)
+    val stepDetectorSensor = sensorManager.getDefaultSensor(TYPE_STEP_DETECTOR)
     val wearableDataClient = Wearable.getDataClient(context)
 
     // Lottie 및 애니메이션 속도 관리
@@ -146,7 +146,7 @@ fun RhythmRoute(
         when (rhythmState.isPlaying) {
             PlayState.PLAYING -> viewModel.playMusic()
             PlayState.PAUSE -> viewModel.pauseMusic(true)
-            PlayState.STOP -> viewModel.postRhythmRecordToSave()
+            PlayState.STOP -> viewModel.recordCurrentStepAccuracy()
             PlayState.DEFAULT -> viewModel.pauseMusic(false)
         }
     }

--- a/presentation/src/main/java/com/kkkk/presentation/main/rhythm/RhythmScreen.kt
+++ b/presentation/src/main/java/com/kkkk/presentation/main/rhythm/RhythmScreen.kt
@@ -120,7 +120,7 @@ fun RhythmRoute(
 
     LaunchedEffect(rhythmState.bit, rhythmState.bpm, rhythmState.selectedMode) {
         if (!File(context.filesDir, rhythmState.filename).exists()) {
-            viewModel.getRhythmUrlState(File(context.filesDir, rhythmState.filename).toPath())
+            viewModel.downloadNewMusicFile(File(context.filesDir, rhythmState.filename).toPath())
         } else {
             viewModel.updateIsPlayerLoaded(false)
         }

--- a/presentation/src/main/java/com/kkkk/presentation/main/rhythm/RhythmState.kt
+++ b/presentation/src/main/java/com/kkkk/presentation/main/rhythm/RhythmState.kt
@@ -46,16 +46,11 @@ data class RhythmState(
             else -> R.drawable.img_rhythm_bg_purple
         }
 
+    val animationSpeed: Float
+        get() = if (selectedMode == RhythmMode.RHYTHM) bpm / FLOAT_80 else 0.75F
 
-    companion object {
-        const val MIN_BPM = 60
-        const val MAX_BPM = 120
-        const val MIN_BIT = 2
-        const val MAX_BIT = 8
-
-        const val STRETCH_MUSIC_FILE = "stempo_bpm_60_bit_2"
-
-        fun findMusicByBpm(bpm: Int) = when (bpm / 20) {
+    val musicByBpm: Int
+        get() = when (bpm / 20) {
             3 -> R.raw.music_bpm_60
             4 -> R.raw.music_bpm_80
             5 -> R.raw.music_bpm_100
@@ -63,12 +58,23 @@ data class RhythmState(
             else -> R.raw.music_bpm_60
         }
 
-        fun findSpeedByBpm(bpm: Int) = when (bpm % 20) {
+    val speedByBpm: Float
+        get() = when (bpm % 20) {
             0 -> 1.0f
             5 -> 1.08f
             10 -> 1.16f
             15 -> 1.25f
             else -> 1.0f
         }
+
+    companion object {
+        const val MIN_BPM = 60
+        const val MAX_BPM = 120
+        const val MIN_BIT = 2
+        const val MAX_BIT = 8
+
+        const val FLOAT_80 = 80.00000000000000000000F
+
+        const val STRETCH_MUSIC_FILE = "stempo_bpm_60_bit_2"
     }
 }

--- a/presentation/src/main/java/com/kkkk/presentation/main/rhythm/RhythmViewModel.kt
+++ b/presentation/src/main/java/com/kkkk/presentation/main/rhythm/RhythmViewModel.kt
@@ -234,34 +234,38 @@ constructor(
 
     fun addStepCount() {
         _rhythmState.update { it.copy(stepCount = it.stepCount + 1) }
+        val currentTime = System.currentTimeMillis()
         if (rhythmState.value.stepCount < 2) {
-            _beforeStepTime.value = System.currentTimeMillis()
+            _beforeStepTime.value = currentTime
             return
         }
-        if (rhythmState.value.stepCount % 2 == 0) {
-            _oddStepCount.value += 1
-            _oddStepTime.value += System.currentTimeMillis() - _beforeStepTime.value
+        val isEven = rhythmState.value.stepCount % 2 == 0
+        val elapsedTime = currentTime - _beforeStepTime.value
+        if (isEven) {
+            _evenStepCount.value++
+            _evenStepTime.value += elapsedTime
         } else {
-            _evenStepCount.value += 1
-            _evenStepTime.value += System.currentTimeMillis() - _beforeStepTime.value
+            _oddStepCount.value++
+            _oddStepTime.value += elapsedTime
         }
-        _beforeStepTime.value = System.currentTimeMillis()
+        _beforeStepTime.value = currentTime
     }
 
-    fun postRhythmRecordToSave() {
-        val isInvalidStep =
-            (_oddStepCount.value == 0 || _evenStepCount.value == 0) && wearableAccuracy == 0.0
+    fun recordCurrentStepAccuracy() {
         val accuracy = calculateAccuracy()
-        if (isInvalidStep || accuracy == 0.0) {
+        if (accuracy == 0.0) {
             resetStepCount()
-            return
+        } else {
+            postRhythmRecordToSave(accuracy)
         }
+    }
+
+    fun postRhythmRecordToSave(accuracy: Double) {
         viewModelScope.launch {
             rhythmRepository.postRhythmRecord(
                 RecordRequestModel(
-                    accuracy,
-                    0,
-                    rhythmState.value.stepCount
+                    accuracy = accuracy,
+                    steps = rhythmState.value.stepCount,
                 )
             ).onSuccess {
                 resetStepCount()
@@ -273,12 +277,20 @@ constructor(
     }
 
     private fun calculateAccuracy(): Double {
-        return if (wearableAccuracy == 0.0) {
-            val time1 = _oddStepTime.value.toDouble() / _oddStepCount.value
-            val time2 = _evenStepTime.value.toDouble() / _evenStepCount.value
-            (1.0 - kotlin.math.abs(time1 - time2) / (time1 + time2)) * 100
-        } else {
-            wearableAccuracy
+        when {
+            wearableAccuracy != 0.0 -> {
+                return wearableAccuracy
+            }
+
+            _oddStepCount.value == 0 || _evenStepCount.value == 0 -> {
+                return 0.0
+            }
+
+            else -> {
+                val time1 = _oddStepTime.value.toDouble() / _oddStepCount.value
+                val time2 = _evenStepTime.value.toDouble() / _evenStepCount.value
+                return (1.0 - kotlin.math.abs(time1 - time2) / (time1 + time2)) * 100
+            }
         }
     }
 

--- a/presentation/src/main/java/com/kkkk/presentation/main/rhythm/RhythmViewModel.kt
+++ b/presentation/src/main/java/com/kkkk/presentation/main/rhythm/RhythmViewModel.kt
@@ -4,6 +4,7 @@ import android.content.res.AssetFileDescriptor
 import android.media.MediaPlayer
 import android.media.PlaybackParams
 import android.media.SoundPool
+import android.view.Choreographer
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.kkkk.domain.entity.request.RecordRequestModel
@@ -26,6 +27,7 @@ import java.nio.file.Files
 import java.nio.file.Path
 import javax.inject.Inject
 import kotlin.coroutines.resume
+import kotlin.coroutines.resumeWithException
 
 @HiltViewModel
 class RhythmViewModel
@@ -103,50 +105,58 @@ constructor(
 
     fun setMusicPlayer(soundPoolFile: File, mediaPlayerAfd: AssetFileDescriptor) {
         viewModelScope.launch {
-            beatStream = 0
-            listOf(
-                async { setSoundPoolAsync(soundPoolFile) },
-                async { setMediaPlayerAsync(mediaPlayerAfd) }
-            ).awaitAll()
-            updateIsPlayerLoaded(true)
-            changeIsLoading(false)
+            runCatching {
+                listOf(
+                    async { setSoundPoolAsync(soundPoolFile) },
+                    async { setMediaPlayerAsync(mediaPlayerAfd) }
+                ).awaitAll()
+            }.onSuccess {
+                updateIsPlayerLoaded(true)
+                changeIsLoading(false)
+                mediaPlayerAfd.close()
+            }.onFailure {
+                _rhythmSideEffect.emit(RhythmSideEffect.ErrorToast)
+            }
         }
     }
 
     private suspend fun setSoundPoolAsync(file: File) {
         suspendCancellableCoroutine<Unit> { continuation ->
-            if (file.exists()) {
+            runCatching {
                 soundPool = SoundPool.Builder().setMaxStreams(1).build().apply {
                     setOnLoadCompleteListener { _, sampleId, _ ->
                         if (sampleId == beatSound) {
                             continuation.resume(Unit)
+                        } else {
+                            continuation.resumeWithException(IllegalStateException())
                         }
                     }
                 }
+                beatStream = 0
                 beatSound = soundPool.load(file.absolutePath, 1)
-            } else {
-                viewModelScope.launch {
-                    _rhythmSideEffect.emit(RhythmSideEffect.ErrorToast)
-                    continuation.resume(Unit)
-                }
-            }
-            continuation.invokeOnCancellation { soundPool.release() }
+            }.onFailure { continuation.resumeWithException(it) }
         }
     }
 
     private suspend fun setMediaPlayerAsync(afd: AssetFileDescriptor) {
         suspendCancellableCoroutine<Unit> { continuation ->
-            mediaPlayer = MediaPlayer().apply {
-                if (!isPlaying) {
+            runCatching {
+                mediaPlayer = MediaPlayer().apply {
                     reset()
+                    setOnPreparedListener { continuation.resume(Unit) }
+                    setOnErrorListener { _, _, _ ->
+                        continuation.resumeWithException(IllegalStateException())
+                        true
+                    }
                     setDataSource(afd.fileDescriptor, afd.startOffset, afd.length)
-                    afd.close()
                     isLooping = true
                     setVolume(0.2f, 0.2f)
-                    prepareAsync()
-                    continuation.resume(Unit)
+                    if (rhythmState.value.selectedMode == RhythmMode.RHYTHM) {
+                        playbackParams = PlaybackParams().setSpeed(rhythmState.value.speedByBpm)
+                    }
                 }
-            }
+                mediaPlayer.prepareAsync()
+            }.onFailure { continuation.resumeWithException(it) }
         }
     }
 
@@ -156,25 +166,17 @@ constructor(
     }
 
     fun playMusic() {
-        viewModelScope.launch {
-            if (rhythmState.value.isPlayerLoaded) {
-                listOf(
-                    async { playMediaPlayerWithSpeed() },
-                    async { playOrResumeSoundPool() },
-                ).awaitAll()
-            } else {
+        if (rhythmState.value.isPlayerLoaded) {
+            Choreographer.getInstance().postFrameCallback {
+                mediaPlayer.start()
+                playOrResumeSoundPool()
+            }
+        } else {
+            viewModelScope.launch {
                 changeIsPlaying(PlayState.DEFAULT)
                 _rhythmSideEffect.emit(RhythmSideEffect.ErrorToast)
             }
         }
-    }
-
-    private fun playMediaPlayerWithSpeed() {
-        mediaPlayer.apply {
-            if (rhythmState.value.selectedMode == RhythmMode.RHYTHM) {
-                playbackParams = PlaybackParams().setSpeed(rhythmState.value.speedByBpm)
-            }
-        }.start()
     }
 
     private fun playOrResumeSoundPool() {
@@ -186,14 +188,12 @@ constructor(
     }
 
     fun pauseMusic(isDialogNeeded: Boolean) {
-        viewModelScope.launch {
-            listOf(
-                async { if (beatStream != 0) soundPool.pause(beatStream) },
-                async { if (mediaPlayer.isPlaying) mediaPlayer.pause() }
-            ).awaitAll()
-            if (isDialogNeeded && rhythmState.value.selectedMode == RhythmMode.RHYTHM) {
-                showSaveDialog(true)
-            }
+        Choreographer.getInstance().postFrameCallback {
+            if (beatStream != 0) soundPool.pause(beatStream)
+            if (mediaPlayer.isPlaying) mediaPlayer.pause()
+        }
+        if (isDialogNeeded && rhythmState.value.selectedMode == RhythmMode.RHYTHM) {
+            showSaveDialog(true)
         }
     }
 

--- a/presentation/src/main/java/com/kkkk/presentation/main/rhythm/RhythmViewModel.kt
+++ b/presentation/src/main/java/com/kkkk/presentation/main/rhythm/RhythmViewModel.kt
@@ -11,7 +11,6 @@ import com.kkkk.domain.entity.request.RhythmRequestModel
 import com.kkkk.domain.repository.RhythmRepository
 import com.kkkk.domain.repository.UserRepository
 import com.kkkk.presentation.manager.PhoneDataManager
-import com.kkkk.presentation.xmlmain.xmlrhythm.XmlRhythmFragment.Companion.findSpeedByBpm
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.async
 import kotlinx.coroutines.awaitAll
@@ -173,7 +172,7 @@ constructor(
     private fun playMediaPlayerWithSpeed() {
         mediaPlayer.apply {
             if (rhythmState.value.selectedMode == RhythmMode.RHYTHM) {
-                playbackParams = PlaybackParams().setSpeed(findSpeedByBpm(rhythmState.value.bpm))
+                playbackParams = PlaybackParams().setSpeed(rhythmState.value.speedByBpm)
             }
         }.start()
     }
@@ -257,7 +256,8 @@ constructor(
     }
 
     fun postRhythmRecordToSave() {
-        val isInvalidStep = (_oddStepCount.value == 0 || _evenStepCount.value == 0) && wearableAccuracy == 0.0
+        val isInvalidStep =
+            (_oddStepCount.value == 0 || _evenStepCount.value == 0) && wearableAccuracy == 0.0
         val accuracy = calculateAccuracy()
         if (isInvalidStep || accuracy == 0.0) {
             resetStepCount()
@@ -316,8 +316,6 @@ constructor(
     }
 
     companion object {
-        const val FLOAT_80 = 80.00000000000000000000F
-
         const val KEY_RECORD = "KEY_RECORD"
         const val KEY_START = "KEY_START"
         const val KEY_END = "KEY_END"

--- a/presentation/src/main/java/com/kkkk/presentation/main/rhythm/RhythmViewModel.kt
+++ b/presentation/src/main/java/com/kkkk/presentation/main/rhythm/RhythmViewModel.kt
@@ -197,46 +197,39 @@ constructor(
         }
     }
 
-    fun getRhythmUrlState(filePath: Path) {
+    fun downloadNewMusicFile(filePath: Path) {
         changeIsLoading(true)
         viewModelScope.launch {
-            rhythmRepository.postToGetRhythmUrl(
-                RhythmRequestModel(
-                    rhythmState.value.bpm,
-                    rhythmState.value.bit
-                )
-            ).onSuccess {
-                getRhythmWavFile(it, filePath)
-            }.onFailure {
-                _rhythmSideEffect.emit(RhythmSideEffect.ErrorToast)
-            }
-        }
-    }
-
-    private fun getRhythmWavFile(url: String, filePath: Path) {
-        viewModelScope.launch {
-            rhythmRepository.getRhythmWav(url)
-                .onSuccess { wav ->
-                    saveWavFile(wav, filePath)
-                }.onFailure {
-                    _rhythmSideEffect.emit(RhythmSideEffect.ErrorToast)
-                }
-        }
-    }
-
-    private fun saveWavFile(wavFile: ByteArray, filePath: Path) {
-        viewModelScope.launch {
             runCatching {
-                Files.newOutputStream(filePath).use { outputStream ->
-                    outputStream.write(wavFile)
-                    outputStream.flush()
-                }
+                val url = getRhythmUrl()
+                val wavFile = getRhythmFile(url)
+                saveRhythmFile(wavFile, filePath)
             }.onSuccess {
                 updateIsPlayerLoaded(false)
             }.onFailure {
                 _rhythmSideEffect.emit(RhythmSideEffect.ErrorToast)
             }
         }
+    }
+
+    private suspend fun getRhythmUrl(): String =
+        rhythmRepository.postToGetRhythmUrl(
+            RhythmRequestModel(
+                rhythmState.value.bpm,
+                rhythmState.value.bit
+            )
+        ).getOrThrow()
+
+    private suspend fun getRhythmFile(url: String): ByteArray =
+        rhythmRepository.getRhythmWav(url).getOrThrow()
+
+    private suspend fun saveRhythmFile(wavFile: ByteArray, filePath: Path) {
+        runCatching {
+            Files.newOutputStream(filePath).use { outputStream ->
+                outputStream.write(wavFile)
+                outputStream.flush()
+            }
+        }.getOrThrow()
     }
 
     fun addStepCount() {


### PR DESCRIPTION
- closed #95

## *⛳️ Work Description*
- launchedEffect에서 state에 종속적인 변수들 모두 state 내 동적 계산으로 조정
- musicplayer 설정 로직에서 viewModelScope의 중첩 호출을 제거하고, suspend 함수로 분리
- musicplayer 설정 로직에서 continuation.resumeWithException 으로 모든 예외처리 진행 및 최상단 runCatching으로 오류 부모 함수에서 처리하도록 설정
- 음악 재생 부분 await 대신 Choreographer 사용으로 프레임 렌더링 직전에 mediaPlayer와 SoundPool을 동시에 시작 및 정지하도록 구현
- 정확도 계산 함수 가독성 개선

## *📢 To Reviewers*
- 기록뷰 작업하기 전에, 리듬뷰 로직에서 다듬고 싶은 부분들이 더 보여서 추가 PR 올리고 진행하겟슴다 -!