### PR TITLE
[UI/#99] 프로필뷰 / Compose Migration

### DIFF
--- a/presentation/src/main/java/com/kkkk/presentation/main/component/ModifierExt.kt
+++ b/presentation/src/main/java/com/kkkk/presentation/main/component/ModifierExt.kt
@@ -1,4 +1,4 @@
-package com.kkkk.presentation.main.rhythm.component
+package com.kkkk.presentation.main.component
 
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.interaction.MutableInteractionSource

--- a/presentation/src/main/java/com/kkkk/presentation/main/component/OneButtonDialog.kt
+++ b/presentation/src/main/java/com/kkkk/presentation/main/component/OneButtonDialog.kt
@@ -1,4 +1,4 @@
-package com.kkkk.presentation.main.rhythm.component
+package com.kkkk.presentation.main.component
 
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Box
@@ -12,6 +12,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
@@ -21,9 +22,11 @@ import com.kkkk.presentation.main.theme.Purple10
 import com.kkkk.presentation.main.theme.Purple50
 import com.kkkk.presentation.main.theme.StempoTheme
 import com.kkkk.presentation.main.theme.White
+import com.kkkk.stempo.presentation.R
 
 @Composable
-fun RhythmSyncDialog(
+fun OneButtonDialog(
+    content: String = "",
     onConfirmClick: () -> Unit = {},
     onDismissRequest: () -> Unit = {}
 ) {
@@ -35,7 +38,7 @@ fun RhythmSyncDialog(
             horizontalAlignment = Alignment.CenterHorizontally
         ) {
             Text(
-                text = "워치와 리듬 동기화를 위해\n스템포 워치 앱 화면을 켜고\n확인 버튼을 눌러주세요",
+                text = content,
                 style = StempoTheme.typography.head3.copy(
                     lineHeight = 28.sp
                 ),
@@ -67,6 +70,8 @@ fun RhythmSyncDialog(
 @Composable
 fun RhythmSyncDialogPreview() {
     StempoTheme {
-        RhythmSyncDialog()
+        OneButtonDialog(
+            content = stringResource(R.string.rhythm_wearable_sync)
+        )
     }
 }

--- a/presentation/src/main/java/com/kkkk/presentation/main/component/TwoButtonDialog.kt
+++ b/presentation/src/main/java/com/kkkk/presentation/main/component/TwoButtonDialog.kt
@@ -1,4 +1,4 @@
-package com.kkkk.presentation.main.rhythm.component
+package com.kkkk.presentation.main.component
 
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
@@ -24,10 +24,13 @@ import com.kkkk.presentation.main.theme.White
 import com.kkkk.stempo.presentation.R
 
 @Composable
-fun RhythmStopDialog(
-    onSaveClick: () -> Unit,
-    onPauseClick: () -> Unit,
-    onDismissRequest: () -> Unit
+fun TwoButtonDialog(
+    content: String = "",
+    firstBtnText: String = "",
+    secondBtnText: String = "",
+    onFirstBtnClick: () -> Unit = {},
+    onSecondBtnClick: () -> Unit = {},
+    onDismissRequest: () -> Unit = {},
 ) {
     Dialog(onDismissRequest = onDismissRequest) {
         Column(
@@ -37,7 +40,7 @@ fun RhythmStopDialog(
             horizontalAlignment = Alignment.CenterHorizontally
         ) {
             Text(
-                text = stringResource(R.string.rhythm_stop_tv_title),
+                text = content,
                 style = StempoTheme.typography.head3.copy(
                     lineHeight = 28.sp
                 ),
@@ -57,8 +60,8 @@ fun RhythmStopDialog(
                         .background(color = Purple10, shape = RoundedCornerShape(12.dp))
                         .padding(vertical = 15.dp)
                         .weight(1f)
-                        .clickableWithoutRipple { onSaveClick() },
-                    text = stringResource(R.string.rhythm_stop_btn_save),
+                        .clickableWithoutRipple { onFirstBtnClick() },
+                    text = firstBtnText,
                     style = StempoTheme.typography.head4,
                     textAlign = TextAlign.Center,
                     color = Purple50
@@ -69,8 +72,8 @@ fun RhythmStopDialog(
                         .background(color = Purple50, shape = RoundedCornerShape(12.dp))
                         .padding(vertical = 15.dp)
                         .weight(1f)
-                        .clickableWithoutRipple { onPauseClick() },
-                    text = stringResource(R.string.rhythm_stop_btn_pause),
+                        .clickableWithoutRipple { onSecondBtnClick() },
+                    text = secondBtnText,
                     style = StempoTheme.typography.head4,
                     textAlign = TextAlign.Center,
                     color = Purple10
@@ -84,10 +87,10 @@ fun RhythmStopDialog(
 @Composable
 fun RhythmStopDialogPreview() {
     StempoTheme {
-        RhythmStopDialog(
-            onSaveClick = {},
-            onPauseClick = {},
-            onDismissRequest = {}
+        TwoButtonDialog(
+            content = stringResource(R.string.rhythm_stop_tv_title),
+            firstBtnText = stringResource(R.string.rhythm_stop_btn_save),
+            secondBtnText = stringResource(R.string.rhythm_stop_btn_pause),
         )
     }
 }

--- a/presentation/src/main/java/com/kkkk/presentation/main/profile/ProfileScreen.kt
+++ b/presentation/src/main/java/com/kkkk/presentation/main/profile/ProfileScreen.kt
@@ -1,5 +1,7 @@
 package com.kkkk.presentation.main.profile
 
+import android.content.Intent
+import android.net.Uri
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
 import androidx.compose.foundation.border
@@ -29,12 +31,14 @@ import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.google.accompanist.systemuicontroller.rememberSystemUiController
 import com.kkkk.core.extension.stringOf
 import com.kkkk.core.extension.toast
+import com.kkkk.presentation.main.profile.model.ProfileButtonType
 import com.kkkk.presentation.main.rhythm.component.clickableWithoutRipple
 import com.kkkk.presentation.main.theme.Gray100
 import com.kkkk.presentation.main.theme.Gray200
 import com.kkkk.presentation.main.theme.Gray500
 import com.kkkk.presentation.main.theme.StempoTheme
 import com.kkkk.presentation.main.theme.White
+import com.kkkk.stempo.presentation.BuildConfig
 import com.kkkk.stempo.presentation.R
 
 @Composable
@@ -60,25 +64,32 @@ fun ProfileRoute(
         systemUiController.setStatusBarColor(color = Gray100)
     }
 
+    LaunchedEffect(profileState.clickedWebsiteUrl) {
+        if (profileState.clickedWebsiteUrl.isNotEmpty()) {
+            context.startActivity(
+                Intent(Intent.ACTION_VIEW, Uri.parse(profileState.clickedWebsiteUrl))
+            )
+            viewModel.updateWebsiteUrl("")
+        }
+    }
+
     ProfileScreen(
-        profileState = profileState,
-        versionText = "",
-        onAnnounceBtnClick = { },
-        onFaqBtnClick = { },
-        onVoiceBtnClick = { },
-        onSuggestBtnClick = { },
+        versionText = BuildConfig.VERSION_NAME,
+        onAnnounceBtnClick = viewModel::startWebsiteWithUrl,
+        onFaqBtnClick = viewModel::startWebsiteWithUrl,
+        onSuggestBtnClick = viewModel::startWebsiteWithUrl,
+        onVoiceBtnClick = viewModel::showNotPreparedToast,
         onWithdrawBtnClick = { }
     )
 }
 
 @Composable
 private fun ProfileScreen(
-    profileState: ProfileState,
     versionText: String = "",
-    onAnnounceBtnClick: () -> Unit = {},
-    onFaqBtnClick: () -> Unit = {},
+    onAnnounceBtnClick: (ProfileButtonType) -> Unit = {},
+    onFaqBtnClick: (ProfileButtonType) -> Unit = {},
+    onSuggestBtnClick: (ProfileButtonType) -> Unit = {},
     onVoiceBtnClick: () -> Unit = {},
-    onSuggestBtnClick: () -> Unit = {},
     onWithdrawBtnClick: () -> Unit = {},
 ) {
     Box(
@@ -91,16 +102,16 @@ private fun ProfileScreen(
 
             ProfileContentBox(
                 firstItemText = stringResource(id = R.string.profile_btn_announce),
-                onFirstItemClick = onAnnounceBtnClick,
+                onFirstItemClick = { onAnnounceBtnClick(ProfileButtonType.BTN_ANNOUNCE) },
                 secondItemText = stringResource(id = R.string.profile_btn_faq),
-                onSecondItemClick = onFaqBtnClick,
+                onSecondItemClick = { onFaqBtnClick(ProfileButtonType.BTN_FAQ) }
             )
 
             ProfileContentBox(
-                firstItemText = stringResource(id = R.string.profile_btn_voice),
-                onFirstItemClick = onVoiceBtnClick,
-                secondItemText = stringResource(id = R.string.profile_btn_suggest),
-                onSecondItemClick = onSuggestBtnClick,
+                firstItemText = stringResource(id = R.string.profile_btn_suggest),
+                onFirstItemClick = { onSuggestBtnClick(ProfileButtonType.BTN_SUGGEST) },
+                secondItemText = stringResource(id = R.string.profile_btn_voice),
+                onSecondItemClick = onVoiceBtnClick
             )
 
             ProfileContentBox(
@@ -173,7 +184,7 @@ fun ProfileContentItem(
         modifier = modifier
             .padding(vertical = 18.dp, horizontal = 20.dp)
             .fillMaxWidth()
-            .clickableWithoutRipple { if (versionText.isNotEmpty()) onClick() },
+            .clickableWithoutRipple { onClick() },
         verticalAlignment = Alignment.CenterVertically,
         horizontalArrangement = Arrangement.SpaceBetween
     ) {
@@ -200,6 +211,6 @@ fun ProfileContentItem(
 @Composable
 fun ProfileScreenPreview() {
     StempoTheme {
-        ProfileScreen(profileState = ProfileState(), versionText = "v1.0.0")
+        ProfileScreen(versionText = "v1.0.0")
     }
 }

--- a/presentation/src/main/java/com/kkkk/presentation/main/profile/ProfileScreen.kt
+++ b/presentation/src/main/java/com/kkkk/presentation/main/profile/ProfileScreen.kt
@@ -4,20 +4,66 @@ import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
-import androidx.compose.ui.Alignment
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.lifecycle.compose.LocalLifecycleOwner
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import com.google.accompanist.systemuicontroller.rememberSystemUiController
+import com.kkkk.core.extension.stringOf
+import com.kkkk.core.extension.toast
+import com.kkkk.presentation.main.theme.Gray100
+import com.kkkk.presentation.main.theme.StempoTheme
+import com.kkkk.stempo.presentation.R
 
 @Composable
-fun ProfileRoute() {
-    ProfileScreen()
+fun ProfileRoute(
+    viewModel: ProfileViewModel = hiltViewModel()
+) {
+    val profileState by viewModel.profileState.collectAsStateWithLifecycle()
+
+    val lifecycleOwner = LocalLifecycleOwner.current
+    val context = LocalContext.current
+    val systemUiController = rememberSystemUiController()
+
+    LaunchedEffect(viewModel.profileSideEffect, lifecycleOwner) {
+        viewModel.profileSideEffect.collect { sideEffect ->
+            when (sideEffect) {
+                ProfileSideEffect.ErrorToast -> context.toast(context.stringOf(R.string.error_msg))
+                ProfileSideEffect.NotPreparedToast -> context.toast(context.stringOf(R.string.profile_not_prepared))
+            }
+        }
+    }
+
+    LaunchedEffect(Unit) {
+        systemUiController.setStatusBarColor(color = Gray100)
+    }
+
+    ProfileScreen(
+        profileState = profileState,
+        onClearBtnClick = { }
+    )
 }
 
 @Composable
-private fun ProfileScreen() {
+private fun ProfileScreen(
+    profileState: ProfileState,
+    onClearBtnClick: () -> Unit = {},
+) {
     Box(
         modifier = Modifier.fillMaxSize(),
-        contentAlignment = Alignment.Center
     ) {
         Text(text = "Profile Screen")
+    }
+}
+
+@Preview(showBackground = true)
+@Composable
+fun ProfileScreenPreview() {
+    StempoTheme {
+        ProfileScreen(profileState = ProfileState())
     }
 }

--- a/presentation/src/main/java/com/kkkk/presentation/main/profile/ProfileScreen.kt
+++ b/presentation/src/main/java/com/kkkk/presentation/main/profile/ProfileScreen.kt
@@ -1,22 +1,40 @@
 package com.kkkk.presentation.main.profile
 
+import androidx.compose.foundation.Image
+import androidx.compose.foundation.background
+import androidx.compose.foundation.border
+import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.res.vectorResource
 import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.LocalLifecycleOwner
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.google.accompanist.systemuicontroller.rememberSystemUiController
 import com.kkkk.core.extension.stringOf
 import com.kkkk.core.extension.toast
+import com.kkkk.presentation.main.rhythm.component.clickableWithoutRipple
 import com.kkkk.presentation.main.theme.Gray100
+import com.kkkk.presentation.main.theme.Gray200
+import com.kkkk.presentation.main.theme.Gray500
 import com.kkkk.presentation.main.theme.StempoTheme
+import com.kkkk.presentation.main.theme.White
 import com.kkkk.stempo.presentation.R
 
 @Composable
@@ -44,19 +62,137 @@ fun ProfileRoute(
 
     ProfileScreen(
         profileState = profileState,
-        onClearBtnClick = { }
+        versionText = "",
+        onAnnounceBtnClick = { },
+        onFaqBtnClick = { },
+        onVoiceBtnClick = { },
+        onSuggestBtnClick = { },
+        onWithdrawBtnClick = { }
     )
 }
 
 @Composable
 private fun ProfileScreen(
     profileState: ProfileState,
-    onClearBtnClick: () -> Unit = {},
+    versionText: String = "",
+    onAnnounceBtnClick: () -> Unit = {},
+    onFaqBtnClick: () -> Unit = {},
+    onVoiceBtnClick: () -> Unit = {},
+    onSuggestBtnClick: () -> Unit = {},
+    onWithdrawBtnClick: () -> Unit = {},
 ) {
     Box(
-        modifier = Modifier.fillMaxSize(),
+        modifier = Modifier
+            .background(Gray100)
+            .fillMaxSize(),
     ) {
-        Text(text = "Profile Screen")
+        Column {
+            ProfileTitle()
+
+            ProfileContentBox(
+                firstItemText = stringResource(id = R.string.profile_btn_announce),
+                onFirstItemClick = onAnnounceBtnClick,
+                secondItemText = stringResource(id = R.string.profile_btn_faq),
+                onSecondItemClick = onFaqBtnClick,
+            )
+
+            ProfileContentBox(
+                firstItemText = stringResource(id = R.string.profile_btn_voice),
+                onFirstItemClick = onVoiceBtnClick,
+                secondItemText = stringResource(id = R.string.profile_btn_suggest),
+                onSecondItemClick = onSuggestBtnClick,
+            )
+
+            ProfileContentBox(
+                firstItemText = stringResource(id = R.string.profile_version),
+                versionText = versionText,
+                secondItemText = stringResource(id = R.string.profile_btn_withdraw),
+                onSecondItemClick = onWithdrawBtnClick,
+            )
+        }
+    }
+}
+
+@Composable
+fun ProfileTitle(
+    modifier: Modifier = Modifier
+) {
+    Row(
+        modifier = modifier.padding(start = 16.dp, top = 24.dp),
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        Image(
+            imageVector = ImageVector.vectorResource(R.drawable.ic_logo_purple),
+            contentDescription = null,
+        )
+        Text(
+            text = stringResource(id = R.string.profile_tv_title),
+            style = StempoTheme.typography.head2,
+            modifier = Modifier.padding(start = 8.dp)
+        )
+    }
+}
+
+@Composable
+fun ProfileContentBox(
+    modifier: Modifier = Modifier,
+    firstItemText: String = "",
+    onFirstItemClick: () -> Unit = {},
+    versionText: String = "",
+    secondItemText: String = "",
+    onSecondItemClick: () -> Unit = {},
+) {
+    Column(
+        modifier = modifier
+            .padding(horizontal = 16.dp)
+            .padding(top = 12.dp)
+            .background(White, RoundedCornerShape(8.dp))
+            .border(1.dp, Gray200, RoundedCornerShape(8.dp))
+            .fillMaxWidth()
+    ) {
+        ProfileContentItem(
+            text = firstItemText,
+            versionText = versionText,
+            onClick = onFirstItemClick
+        )
+        ProfileContentItem(
+            text = secondItemText,
+            onClick = onSecondItemClick
+        )
+    }
+}
+
+@Composable
+fun ProfileContentItem(
+    modifier: Modifier = Modifier,
+    text: String = "",
+    versionText: String = "",
+    onClick: () -> Unit = {},
+) {
+    Row(
+        modifier = modifier
+            .padding(vertical = 18.dp, horizontal = 20.dp)
+            .fillMaxWidth()
+            .clickableWithoutRipple { if (versionText.isNotEmpty()) onClick() },
+        verticalAlignment = Alignment.CenterVertically,
+        horizontalArrangement = Arrangement.SpaceBetween
+    ) {
+        Text(
+            text = text,
+            style = StempoTheme.typography.head4
+        )
+        if (versionText.isEmpty()) {
+            Image(
+                imageVector = ImageVector.vectorResource(R.drawable.ic_next_gray),
+                contentDescription = null
+            )
+        } else {
+            Text(
+                text = versionText,
+                style = StempoTheme.typography.body2,
+                color = Gray500
+            )
+        }
     }
 }
 
@@ -64,6 +200,6 @@ private fun ProfileScreen(
 @Composable
 fun ProfileScreenPreview() {
     StempoTheme {
-        ProfileScreen(profileState = ProfileState())
+        ProfileScreen(profileState = ProfileState(), versionText = "v1.0.0")
     }
 }

--- a/presentation/src/main/java/com/kkkk/presentation/main/profile/ProfileScreen.kt
+++ b/presentation/src/main/java/com/kkkk/presentation/main/profile/ProfileScreen.kt
@@ -32,7 +32,7 @@ import com.google.accompanist.systemuicontroller.rememberSystemUiController
 import com.kkkk.core.extension.stringOf
 import com.kkkk.core.extension.toast
 import com.kkkk.presentation.main.profile.model.ProfileButtonType
-import com.kkkk.presentation.main.rhythm.component.clickableWithoutRipple
+import com.kkkk.presentation.main.component.clickableWithoutRipple
 import com.kkkk.presentation.main.theme.Gray100
 import com.kkkk.presentation.main.theme.Gray200
 import com.kkkk.presentation.main.theme.Gray500
@@ -74,7 +74,7 @@ fun ProfileRoute(
     }
 
     ProfileScreen(
-        versionText = BuildConfig.VERSION_NAME,
+        versionText = "v ${BuildConfig.VERSION_NAME}",
         onAnnounceBtnClick = viewModel::startWebsiteWithUrl,
         onFaqBtnClick = viewModel::startWebsiteWithUrl,
         onSuggestBtnClick = viewModel::startWebsiteWithUrl,

--- a/presentation/src/main/java/com/kkkk/presentation/main/profile/ProfileScreen.kt
+++ b/presentation/src/main/java/com/kkkk/presentation/main/profile/ProfileScreen.kt
@@ -29,10 +29,12 @@ import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.LocalLifecycleOwner
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.google.accompanist.systemuicontroller.rememberSystemUiController
+import com.jakewharton.processphoenix.ProcessPhoenix
 import com.kkkk.core.extension.stringOf
 import com.kkkk.core.extension.toast
-import com.kkkk.presentation.main.profile.model.ProfileButtonType
+import com.kkkk.presentation.main.component.TwoButtonDialog
 import com.kkkk.presentation.main.component.clickableWithoutRipple
+import com.kkkk.presentation.main.profile.model.ProfileButtonType
 import com.kkkk.presentation.main.theme.Gray100
 import com.kkkk.presentation.main.theme.Gray200
 import com.kkkk.presentation.main.theme.Gray500
@@ -73,14 +75,31 @@ fun ProfileRoute(
         }
     }
 
+    LaunchedEffect(profileState.isProfileCleared) {
+        if(profileState.isProfileCleared) {
+            ProcessPhoenix.triggerRebirth(context)
+        }
+    }
+
     ProfileScreen(
         versionText = "v ${BuildConfig.VERSION_NAME}",
         onAnnounceBtnClick = viewModel::startWebsiteWithUrl,
         onFaqBtnClick = viewModel::startWebsiteWithUrl,
         onSuggestBtnClick = viewModel::startWebsiteWithUrl,
         onVoiceBtnClick = viewModel::showNotPreparedToast,
-        onWithdrawBtnClick = { }
+        onWithdrawBtnClick = { viewModel.updateIsDialogVisible(true) }
     )
+
+    if (profileState.isDialogVisible) {
+        TwoButtonDialog(
+            content = stringResource(R.string.profile_withdraw_content),
+            firstBtnText = stringResource(R.string.profile_withdraw_cancel),
+            secondBtnText = stringResource(R.string.profile_withdraw_delete),
+            onFirstBtnClick = { viewModel.updateIsDialogVisible(false) },
+            onSecondBtnClick = viewModel::withdrawAccount,
+            onDismissRequest = { viewModel.updateIsDialogVisible(false) }
+        )
+    }
 }
 
 @Composable

--- a/presentation/src/main/java/com/kkkk/presentation/main/profile/ProfileScreen.kt
+++ b/presentation/src/main/java/com/kkkk/presentation/main/profile/ProfileScreen.kt
@@ -56,29 +56,27 @@ fun ProfileRoute(
     LaunchedEffect(viewModel.profileSideEffect, lifecycleOwner) {
         viewModel.profileSideEffect.collect { sideEffect ->
             when (sideEffect) {
-                ProfileSideEffect.ErrorToast -> context.toast(context.stringOf(R.string.error_msg))
-                ProfileSideEffect.NotPreparedToast -> context.toast(context.stringOf(R.string.profile_not_prepared))
+                ProfileSideEffect.ErrorToast -> {
+                    context.toast(context.stringOf(R.string.error_msg))
+                }
+
+                ProfileSideEffect.NotPreparedToast -> {
+                    context.toast(context.stringOf(R.string.profile_not_prepared))
+                }
+
+                ProfileSideEffect.ProfileCleared -> {
+                    ProcessPhoenix.triggerRebirth(context)
+                }
+
+                is ProfileSideEffect.WebsiteClicked -> {
+                    context.startActivity(Intent(Intent.ACTION_VIEW, Uri.parse(sideEffect.url)))
+                }
             }
         }
     }
 
     LaunchedEffect(Unit) {
         systemUiController.setStatusBarColor(color = Gray100)
-    }
-
-    LaunchedEffect(profileState.clickedWebsiteUrl) {
-        if (profileState.clickedWebsiteUrl.isNotEmpty()) {
-            context.startActivity(
-                Intent(Intent.ACTION_VIEW, Uri.parse(profileState.clickedWebsiteUrl))
-            )
-            viewModel.updateWebsiteUrl("")
-        }
-    }
-
-    LaunchedEffect(profileState.isProfileCleared) {
-        if(profileState.isProfileCleared) {
-            ProcessPhoenix.triggerRebirth(context)
-        }
     }
 
     ProfileScreen(
@@ -121,14 +119,14 @@ private fun ProfileScreen(
 
             ProfileContentBox(
                 firstItemText = stringResource(id = R.string.profile_btn_announce),
-                onFirstItemClick = { onAnnounceBtnClick(ProfileButtonType.BTN_ANNOUNCE) },
+                onFirstItemClick = { onAnnounceBtnClick(ProfileButtonType.URL_ANNOUNCE) },
                 secondItemText = stringResource(id = R.string.profile_btn_faq),
-                onSecondItemClick = { onFaqBtnClick(ProfileButtonType.BTN_FAQ) }
+                onSecondItemClick = { onFaqBtnClick(ProfileButtonType.URL_FAQ) }
             )
 
             ProfileContentBox(
                 firstItemText = stringResource(id = R.string.profile_btn_suggest),
-                onFirstItemClick = { onSuggestBtnClick(ProfileButtonType.BTN_SUGGEST) },
+                onFirstItemClick = { onSuggestBtnClick(ProfileButtonType.URL_SUGGEST) },
                 secondItemText = stringResource(id = R.string.profile_btn_voice),
                 onSecondItemClick = onVoiceBtnClick
             )

--- a/presentation/src/main/java/com/kkkk/presentation/main/profile/ProfileSideEffect.kt
+++ b/presentation/src/main/java/com/kkkk/presentation/main/profile/ProfileSideEffect.kt
@@ -3,4 +3,6 @@ package com.kkkk.presentation.main.profile
 sealed class ProfileSideEffect {
     data object ErrorToast : ProfileSideEffect()
     data object NotPreparedToast : ProfileSideEffect()
+    data object ProfileCleared : ProfileSideEffect()
+    data class WebsiteClicked(val url: String) : ProfileSideEffect()
 }

--- a/presentation/src/main/java/com/kkkk/presentation/main/profile/ProfileSideEffect.kt
+++ b/presentation/src/main/java/com/kkkk/presentation/main/profile/ProfileSideEffect.kt
@@ -1,0 +1,6 @@
+package com.kkkk.presentation.main.profile
+
+sealed class ProfileSideEffect {
+    data object ErrorToast : ProfileSideEffect()
+    data object NotPreparedToast : ProfileSideEffect()
+}

--- a/presentation/src/main/java/com/kkkk/presentation/main/profile/ProfileState.kt
+++ b/presentation/src/main/java/com/kkkk/presentation/main/profile/ProfileState.kt
@@ -1,0 +1,6 @@
+package com.kkkk.presentation.main.profile
+
+data class ProfileState(
+    val isDialogVisible: Boolean = false,
+    val isProfileCleared: Boolean = false,
+)

--- a/presentation/src/main/java/com/kkkk/presentation/main/profile/ProfileState.kt
+++ b/presentation/src/main/java/com/kkkk/presentation/main/profile/ProfileState.kt
@@ -3,4 +3,5 @@ package com.kkkk.presentation.main.profile
 data class ProfileState(
     val isDialogVisible: Boolean = false,
     val isProfileCleared: Boolean = false,
+    val clickedWebsiteUrl: String = "",
 )

--- a/presentation/src/main/java/com/kkkk/presentation/main/profile/ProfileState.kt
+++ b/presentation/src/main/java/com/kkkk/presentation/main/profile/ProfileState.kt
@@ -2,6 +2,4 @@ package com.kkkk.presentation.main.profile
 
 data class ProfileState(
     val isDialogVisible: Boolean = false,
-    val isProfileCleared: Boolean = false,
-    val clickedWebsiteUrl: String = "",
 )

--- a/presentation/src/main/java/com/kkkk/presentation/main/profile/ProfileViewModel.kt
+++ b/presentation/src/main/java/com/kkkk/presentation/main/profile/ProfileViewModel.kt
@@ -5,13 +5,11 @@ import androidx.lifecycle.viewModelScope
 import com.kkkk.domain.repository.AuthRepository
 import com.kkkk.domain.repository.UserRepository
 import com.kkkk.presentation.main.profile.model.ProfileButtonType
-import com.kkkk.presentation.xmlmain.xmlprofile.XmlProfileViewModel
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.asSharedFlow
 import kotlinx.coroutines.flow.asStateFlow
-import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 import javax.inject.Inject
 
@@ -28,16 +26,9 @@ constructor(
     private val _profileSideEffect = MutableSharedFlow<ProfileSideEffect>()
     val profileSideEffect = _profileSideEffect.asSharedFlow()
 
-    fun updateWebsiteUrl(url: String) {
-        _profileState.value = _profileState.value.copy(clickedWebsiteUrl = url)
-    }
-
     fun startWebsiteWithUrl(btnType: ProfileButtonType) {
-        when (btnType) {
-            ProfileButtonType.BTN_ANNOUNCE -> updateWebsiteUrl(URL_ANNOUNCE)
-            ProfileButtonType.BTN_FAQ -> updateWebsiteUrl(URL_FAQ)
-            ProfileButtonType.BTN_SUGGEST -> updateWebsiteUrl(URL_SUGGEST)
-            ProfileButtonType.DEFAULT -> updateWebsiteUrl("")
+        viewModelScope.launch {
+            _profileSideEffect.emit(ProfileSideEffect.WebsiteClicked(btnType.url))
         }
     }
 
@@ -57,19 +48,12 @@ constructor(
                 authorization = BEARER + " " + userRepository.getRefreshToken()
             ).onSuccess {
                 userRepository.clearInfo()
-                _profileState.update { it.copy(isProfileCleared = true) }
+                _profileSideEffect.emit(ProfileSideEffect.ProfileCleared)
             }
         }
     }
 
     companion object {
         private const val BEARER = "Bearer"
-
-        private const val URL_ANNOUNCE =
-            "https://field-colt-189.notion.site/Stempo-e8252a5094eb4351819809dc3abd6623?pvs=4"
-        private const val URL_FAQ =
-            "https://field-colt-189.notion.site/FAQ-3e01b4b00b0c4b2c84aaacd79b2b6045?pvs=4"
-        private const val URL_SUGGEST =
-            "https://docs.google.com/forms/d/e/1FAIpQLSfTyRUJzIURmSvIJOgJlqqLCRECVPtTHWj8xCNsBrIIuzwBRA/viewform"
     }
 }

--- a/presentation/src/main/java/com/kkkk/presentation/main/profile/ProfileViewModel.kt
+++ b/presentation/src/main/java/com/kkkk/presentation/main/profile/ProfileViewModel.kt
@@ -1,0 +1,26 @@
+package com.kkkk.presentation.main.profile
+
+import androidx.lifecycle.ViewModel
+import com.kkkk.domain.repository.AuthRepository
+import com.kkkk.domain.repository.UserRepository
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.asSharedFlow
+import kotlinx.coroutines.flow.asStateFlow
+import javax.inject.Inject
+
+@HiltViewModel
+class ProfileViewModel
+@Inject
+constructor(
+    private val authRepository: AuthRepository,
+    private val userRepository: UserRepository,
+) : ViewModel() {
+    private val _profileState = MutableStateFlow(ProfileState())
+    val profileState = _profileState.asStateFlow()
+
+    private val _profileSideEffect = MutableSharedFlow<ProfileSideEffect>()
+    val profileSideEffect = _profileSideEffect.asSharedFlow()
+
+}

--- a/presentation/src/main/java/com/kkkk/presentation/main/profile/ProfileViewModel.kt
+++ b/presentation/src/main/java/com/kkkk/presentation/main/profile/ProfileViewModel.kt
@@ -5,11 +5,13 @@ import androidx.lifecycle.viewModelScope
 import com.kkkk.domain.repository.AuthRepository
 import com.kkkk.domain.repository.UserRepository
 import com.kkkk.presentation.main.profile.model.ProfileButtonType
+import com.kkkk.presentation.xmlmain.xmlprofile.XmlProfileViewModel
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.asSharedFlow
 import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 import javax.inject.Inject
 
@@ -26,7 +28,7 @@ constructor(
     private val _profileSideEffect = MutableSharedFlow<ProfileSideEffect>()
     val profileSideEffect = _profileSideEffect.asSharedFlow()
 
-   fun updateWebsiteUrl(url: String) {
+    fun updateWebsiteUrl(url: String) {
         _profileState.value = _profileState.value.copy(clickedWebsiteUrl = url)
     }
 
@@ -45,7 +47,24 @@ constructor(
         }
     }
 
+    fun updateIsDialogVisible(isVisible: Boolean) {
+        _profileState.value = _profileState.value.copy(isDialogVisible = isVisible)
+    }
+
+    fun withdrawAccount() {
+        viewModelScope.launch {
+            authRepository.unregister(
+                authorization = BEARER + " " + userRepository.getRefreshToken()
+            ).onSuccess {
+                userRepository.clearInfo()
+                _profileState.update { it.copy(isProfileCleared = true) }
+            }
+        }
+    }
+
     companion object {
+        private const val BEARER = "Bearer"
+
         private const val URL_ANNOUNCE =
             "https://field-colt-189.notion.site/Stempo-e8252a5094eb4351819809dc3abd6623?pvs=4"
         private const val URL_FAQ =

--- a/presentation/src/main/java/com/kkkk/presentation/main/profile/ProfileViewModel.kt
+++ b/presentation/src/main/java/com/kkkk/presentation/main/profile/ProfileViewModel.kt
@@ -1,13 +1,16 @@
 package com.kkkk.presentation.main.profile
 
 import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
 import com.kkkk.domain.repository.AuthRepository
 import com.kkkk.domain.repository.UserRepository
+import com.kkkk.presentation.main.profile.model.ProfileButtonType
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.asSharedFlow
 import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.launch
 import javax.inject.Inject
 
 @HiltViewModel
@@ -23,4 +26,31 @@ constructor(
     private val _profileSideEffect = MutableSharedFlow<ProfileSideEffect>()
     val profileSideEffect = _profileSideEffect.asSharedFlow()
 
+   fun updateWebsiteUrl(url: String) {
+        _profileState.value = _profileState.value.copy(clickedWebsiteUrl = url)
+    }
+
+    fun startWebsiteWithUrl(btnType: ProfileButtonType) {
+        when (btnType) {
+            ProfileButtonType.BTN_ANNOUNCE -> updateWebsiteUrl(URL_ANNOUNCE)
+            ProfileButtonType.BTN_FAQ -> updateWebsiteUrl(URL_FAQ)
+            ProfileButtonType.BTN_SUGGEST -> updateWebsiteUrl(URL_SUGGEST)
+            ProfileButtonType.DEFAULT -> updateWebsiteUrl("")
+        }
+    }
+
+    fun showNotPreparedToast() {
+        viewModelScope.launch {
+            _profileSideEffect.emit(ProfileSideEffect.NotPreparedToast)
+        }
+    }
+
+    companion object {
+        private const val URL_ANNOUNCE =
+            "https://field-colt-189.notion.site/Stempo-e8252a5094eb4351819809dc3abd6623?pvs=4"
+        private const val URL_FAQ =
+            "https://field-colt-189.notion.site/FAQ-3e01b4b00b0c4b2c84aaacd79b2b6045?pvs=4"
+        private const val URL_SUGGEST =
+            "https://docs.google.com/forms/d/e/1FAIpQLSfTyRUJzIURmSvIJOgJlqqLCRECVPtTHWj8xCNsBrIIuzwBRA/viewform"
+    }
 }

--- a/presentation/src/main/java/com/kkkk/presentation/main/profile/model/ProfileButtonType.kt
+++ b/presentation/src/main/java/com/kkkk/presentation/main/profile/model/ProfileButtonType.kt
@@ -1,0 +1,5 @@
+package com.kkkk.presentation.main.profile.model
+
+enum class ProfileButtonType {
+    BTN_ANNOUNCE, BTN_FAQ, BTN_SUGGEST, DEFAULT
+}

--- a/presentation/src/main/java/com/kkkk/presentation/main/profile/model/ProfileButtonType.kt
+++ b/presentation/src/main/java/com/kkkk/presentation/main/profile/model/ProfileButtonType.kt
@@ -1,5 +1,7 @@
 package com.kkkk.presentation.main.profile.model
 
-enum class ProfileButtonType {
-    BTN_ANNOUNCE, BTN_FAQ, BTN_SUGGEST, DEFAULT
+enum class ProfileButtonType(val url: String) {
+    URL_ANNOUNCE("https://field-colt-189.notion.site/Stempo-e8252a5094eb4351819809dc3abd6623?pvs=4"),
+    URL_FAQ("https://field-colt-189.notion.site/FAQ-3e01b4b00b0c4b2c84aaacd79b2b6045?pvs=4"),
+    URL_SUGGEST("https://docs.google.com/forms/d/e/1FAIpQLSfTyRUJzIURmSvIJOgJlqqLCRECVPtTHWj8xCNsBrIIuzwBRA/viewform");
 }

--- a/presentation/src/main/java/com/kkkk/presentation/main/record/RecordScreen.kt
+++ b/presentation/src/main/java/com/kkkk/presentation/main/record/RecordScreen.kt
@@ -49,7 +49,7 @@ import com.kkkk.core.extension.stringOf
 import com.kkkk.core.extension.toast
 import com.kkkk.presentation.main.record.component.DottedShape
 import com.kkkk.presentation.main.record.component.RecordLineChart
-import com.kkkk.presentation.main.rhythm.component.clickableWithoutRipple
+import com.kkkk.presentation.main.component.clickableWithoutRipple
 import com.kkkk.presentation.main.theme.Gray100
 import com.kkkk.presentation.main.theme.Gray300
 import com.kkkk.presentation.main.theme.Gray600

--- a/presentation/src/main/java/com/kkkk/presentation/main/rhythm/RhythmScreen.kt
+++ b/presentation/src/main/java/com/kkkk/presentation/main/rhythm/RhythmScreen.kt
@@ -57,6 +57,9 @@ import com.google.android.gms.wearable.DataMapItem
 import com.google.android.gms.wearable.Wearable
 import com.kkkk.core.extension.stringOf
 import com.kkkk.core.extension.toast
+import com.kkkk.presentation.main.component.OneButtonDialog
+import com.kkkk.presentation.main.component.TwoButtonDialog
+import com.kkkk.presentation.main.component.clickableWithoutRipple
 import com.kkkk.presentation.main.rhythm.RhythmState.Companion.STRETCH_MUSIC_FILE
 import com.kkkk.presentation.main.rhythm.RhythmViewModel.Companion.KEY_RECORD
 import com.kkkk.presentation.main.rhythm.RhythmViewModel.Companion.PATH_END
@@ -65,9 +68,6 @@ import com.kkkk.presentation.main.rhythm.RhythmViewModel.Companion.PATH_START
 import com.kkkk.presentation.main.rhythm.component.RhythmBottomSheet
 import com.kkkk.presentation.main.rhythm.component.RhythmChip
 import com.kkkk.presentation.main.rhythm.component.RhythmModeToggle
-import com.kkkk.presentation.main.rhythm.component.RhythmStopDialog
-import com.kkkk.presentation.main.rhythm.component.RhythmSyncDialog
-import com.kkkk.presentation.main.rhythm.component.clickableWithoutRipple
 import com.kkkk.presentation.main.rhythm.model.PlayState
 import com.kkkk.presentation.main.rhythm.model.RhythmMode
 import com.kkkk.presentation.main.theme.Dark
@@ -216,15 +216,19 @@ fun RhythmRoute(
     }
 
     if (rhythmState.isSaveDialogVisible) {
-        RhythmStopDialog(
-            onSaveClick = { viewModel.changeIsPlaying(PlayState.STOP) },
-            onPauseClick = { viewModel.showSaveDialog(false) },
+        TwoButtonDialog(
+            content = stringResource(R.string.rhythm_stop_tv_title),
+            firstBtnText = stringResource(R.string.rhythm_stop_btn_save),
+            secondBtnText = stringResource(R.string.rhythm_stop_btn_pause),
+            onFirstBtnClick = { viewModel.changeIsPlaying(PlayState.STOP) },
+            onSecondBtnClick = { viewModel.showSaveDialog(false) },
             onDismissRequest = { viewModel.showSaveDialog(false) },
         )
     }
 
     if (rhythmState.isSyncDialogVisible) {
-        RhythmSyncDialog(
+        OneButtonDialog(
+            content = stringResource(R.string.rhythm_wearable_sync),
             onConfirmClick = viewModel::sendBpmToWearable,
             onDismissRequest = { viewModel.showSyncDialog(false) },
         )

--- a/presentation/src/main/java/com/kkkk/presentation/main/rhythm/RhythmScreen.kt
+++ b/presentation/src/main/java/com/kkkk/presentation/main/rhythm/RhythmScreen.kt
@@ -68,6 +68,8 @@ import com.kkkk.presentation.main.rhythm.component.RhythmModeToggle
 import com.kkkk.presentation.main.rhythm.component.RhythmStopDialog
 import com.kkkk.presentation.main.rhythm.component.RhythmSyncDialog
 import com.kkkk.presentation.main.rhythm.component.clickableWithoutRipple
+import com.kkkk.presentation.main.rhythm.model.PlayState
+import com.kkkk.presentation.main.rhythm.model.RhythmMode
 import com.kkkk.presentation.main.theme.Dark
 import com.kkkk.presentation.main.theme.StempoTheme
 import com.kkkk.presentation.main.theme.Transparent50

--- a/presentation/src/main/java/com/kkkk/presentation/main/rhythm/RhythmState.kt
+++ b/presentation/src/main/java/com/kkkk/presentation/main/rhythm/RhythmState.kt
@@ -1,6 +1,8 @@
 package com.kkkk.presentation.main.rhythm
 
 import androidx.compose.ui.graphics.Color
+import com.kkkk.presentation.main.rhythm.model.PlayState
+import com.kkkk.presentation.main.rhythm.model.RhythmMode
 import com.kkkk.presentation.main.theme.Green50
 import com.kkkk.presentation.main.theme.Purple50
 import com.kkkk.presentation.main.theme.Sky50

--- a/presentation/src/main/java/com/kkkk/presentation/main/rhythm/RhythmViewModel.kt
+++ b/presentation/src/main/java/com/kkkk/presentation/main/rhythm/RhythmViewModel.kt
@@ -11,6 +11,8 @@ import com.kkkk.domain.entity.request.RecordRequestModel
 import com.kkkk.domain.entity.request.RhythmRequestModel
 import com.kkkk.domain.repository.RhythmRepository
 import com.kkkk.domain.repository.UserRepository
+import com.kkkk.presentation.main.rhythm.model.PlayState
+import com.kkkk.presentation.main.rhythm.model.RhythmMode
 import com.kkkk.presentation.manager.PhoneDataManager
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.async

--- a/presentation/src/main/java/com/kkkk/presentation/main/rhythm/component/RhythmBitItem.kt
+++ b/presentation/src/main/java/com/kkkk/presentation/main/rhythm/component/RhythmBitItem.kt
@@ -10,6 +10,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.unit.dp
+import com.kkkk.presentation.main.component.clickableWithoutRipple
 import com.kkkk.presentation.main.theme.Gray200
 import com.kkkk.presentation.main.theme.Gray600
 import com.kkkk.presentation.main.theme.Purple50

--- a/presentation/src/main/java/com/kkkk/presentation/main/rhythm/component/RhythmBottomSheet.kt
+++ b/presentation/src/main/java/com/kkkk/presentation/main/rhythm/component/RhythmBottomSheet.kt
@@ -34,6 +34,7 @@ import androidx.compose.ui.res.vectorResource
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
+import com.kkkk.presentation.main.component.clickableWithoutRipple
 import com.kkkk.presentation.main.rhythm.RhythmState
 import com.kkkk.presentation.main.rhythm.RhythmState.Companion.MAX_BPM
 import com.kkkk.presentation.main.rhythm.RhythmState.Companion.MIN_BPM

--- a/presentation/src/main/java/com/kkkk/presentation/main/rhythm/component/RhythmBpmItem.kt
+++ b/presentation/src/main/java/com/kkkk/presentation/main/rhythm/component/RhythmBpmItem.kt
@@ -11,6 +11,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.unit.dp
+import com.kkkk.presentation.main.component.clickableWithoutRipple
 import com.kkkk.presentation.main.theme.Gray100
 import com.kkkk.presentation.main.theme.Gray300
 import com.kkkk.presentation.main.theme.Gray500

--- a/presentation/src/main/java/com/kkkk/presentation/main/rhythm/component/RhythmModeToggle.kt
+++ b/presentation/src/main/java/com/kkkk/presentation/main/rhythm/component/RhythmModeToggle.kt
@@ -17,6 +17,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
+import com.kkkk.presentation.main.component.clickableWithoutRipple
 import com.kkkk.presentation.main.rhythm.model.RhythmMode
 import com.kkkk.presentation.main.theme.Black
 import com.kkkk.presentation.main.theme.Gray200

--- a/presentation/src/main/java/com/kkkk/presentation/main/rhythm/component/RhythmModeToggle.kt
+++ b/presentation/src/main/java/com/kkkk/presentation/main/rhythm/component/RhythmModeToggle.kt
@@ -17,7 +17,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
-import com.kkkk.presentation.main.rhythm.RhythmMode
+import com.kkkk.presentation.main.rhythm.model.RhythmMode
 import com.kkkk.presentation.main.theme.Black
 import com.kkkk.presentation.main.theme.Gray200
 import com.kkkk.presentation.main.theme.Gray600

--- a/presentation/src/main/java/com/kkkk/presentation/main/rhythm/component/RhythmUpDownBtn.kt
+++ b/presentation/src/main/java/com/kkkk/presentation/main/rhythm/component/RhythmUpDownBtn.kt
@@ -8,6 +8,7 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.res.vectorResource
 import androidx.compose.ui.unit.dp
+import com.kkkk.presentation.main.component.clickableWithoutRipple
 
 @Composable
 fun RhythmUpDownBtn(

--- a/presentation/src/main/java/com/kkkk/presentation/main/rhythm/model/PlayState.kt
+++ b/presentation/src/main/java/com/kkkk/presentation/main/rhythm/model/PlayState.kt
@@ -1,4 +1,4 @@
-package com.kkkk.presentation.main.rhythm
+package com.kkkk.presentation.main.rhythm.model
 
 enum class PlayState {
     PLAYING, PAUSE, STOP, DEFAULT

--- a/presentation/src/main/java/com/kkkk/presentation/main/rhythm/model/RhythmMode.kt
+++ b/presentation/src/main/java/com/kkkk/presentation/main/rhythm/model/RhythmMode.kt
@@ -1,4 +1,4 @@
-package com.kkkk.presentation.main.rhythm
+package com.kkkk.presentation.main.rhythm.model
 
 enum class RhythmMode(val text: String) {
     RHYTHM("리듬모드"),

--- a/presentation/src/main/res/values/strings.xml
+++ b/presentation/src/main/res/values/strings.xml
@@ -31,6 +31,8 @@
     <string name="rhythm_btn_submit_level">완료하기</string>
     <string name="rhythm_toast_save_success">기록 저장이 완료되었어요!</string>
 
+    <string name="rhythm_wearable_sync">"워치와 리듬 동기화를 위해\n스템포 워치 앱 화면을 켜고\n확인 버튼을 눌러주세요"</string>
+
     <string name="rhythm_stop_tv_title">종료하기를 누르면\n지금까지의 걸음이 기록돼요.\n잠시 멈추시는거라면\n정지하기를 눌러주세요.</string>
     <string name="rhythm_stop_btn_save">종료하기</string>
     <string name="rhythm_stop_btn_pause">정지하기</string>

--- a/presentation/src/main/res/values/strings.xml
+++ b/presentation/src/main/res/values/strings.xml
@@ -66,6 +66,7 @@
     <string name="profile_btn_faq">FAQ</string>
     <string name="profile_btn_voice">불편한 점 얘기하기 (음성)</string>
     <string name="profile_btn_suggest">건의하기</string>
+    <string name="profile_version">버전 정보</string>
     <string name="profile_btn_withdraw">기록 지우기</string>
     <string name="profile_not_prepared">다음 업데이트 때 사용 가능해요!</string>
 

--- a/presentation/src/main/res/values/strings.xml
+++ b/presentation/src/main/res/values/strings.xml
@@ -72,6 +72,10 @@
     <string name="profile_btn_withdraw">기록 지우기</string>
     <string name="profile_not_prepared">다음 업데이트 때 사용 가능해요!</string>
 
+    <string name="profile_withdraw_content">모든 기록이 사라져요!\n정말로 기록을 삭제할까요?</string>
+    <string name="profile_withdraw_cancel">취소하기</string>
+    <string name="profile_withdraw_delete">삭제하기</string>
+
     <string name="study_tv_my">진행해야 할 과제에요!</string>
     <string name="study_tv_teacher">입력한 과제에요!</string>
 

--- a/presentation/src/main/res/values/strings.xml
+++ b/presentation/src/main/res/values/strings.xml
@@ -67,6 +67,7 @@
     <string name="profile_btn_voice">불편한 점 얘기하기 (음성)</string>
     <string name="profile_btn_suggest">건의하기</string>
     <string name="profile_btn_withdraw">기록 지우기</string>
+    <string name="profile_not_prepared">다음 업데이트 때 사용 가능해요!</string>
 
     <string name="study_tv_my">진행해야 할 과제에요!</string>
     <string name="study_tv_teacher">입력한 과제에요!</string>


### PR DESCRIPTION
- closed #99

## *⛳️ Work Description*
- 프로필뷰 UI & 로직 구현
- 리듬뷰에서 사용했던 다이얼로그 재사용화

## *📸 Screenshot*
<!-- 실행 사진이나 영상을 드래그하여 첨부해주세요. -->
<!-- <img src="이미지 주소" width=270 /> -->

https://github.com/user-attachments/assets/a60a2dae-dd3c-442a-9396-8578012eeb9d


## *📢 To Reviewers*
- 중복되는 URL 버튼을 enum class로 했는데, 이렇게 하는게 맞는건지, 좋은 방법이 있을지?